### PR TITLE
Fix/cmd enum handling

### DIFF
--- a/server/cmd/parameter.go
+++ b/server/cmd/parameter.go
@@ -28,6 +28,10 @@ type Parameter interface {
 //
 // Their values will then automatically be set to whichever option returned in Enum.Options is selected by
 // the user.
+//
+// By default, Enum implementations are sent as static enums, which display their type name in the command
+// usage (e.g., <mode: GameMode>). If an enum's options may change at runtime, implement the DynamicEnum
+// interface instead.
 type Enum interface {
 	// Type returns the type of the enum. This type shows up client-side in the command usage, in the spot
 	// where parameter types otherwise are.
@@ -38,6 +42,15 @@ type Enum interface {
 	// the argument passed to the enum parameter will be equal to one of these options. The provided Source
 	// can also be used to change the enums for each player.
 	Options(source Source) []string
+}
+
+// DynamicEnum is an optional interface that Enum implementations may implement to indicate that their
+// options can change at runtime. Enums implementing this interface will be sent as soft/dynamic enums,
+// allowing runtime updates.
+type DynamicEnum interface {
+	Enum
+	// Dynamic returns true if this enum's options may change at runtime.
+	Dynamic() bool
 }
 
 // ParamDescriber may be implemented by a Runnable to programmatically describe its parameters

--- a/server/cmd/parameter.go
+++ b/server/cmd/parameter.go
@@ -28,10 +28,6 @@ type Parameter interface {
 //
 // Their values will then automatically be set to whichever option returned in Enum.Options is selected by
 // the user.
-//
-// By default, Enum implementations are sent as static enums, which display their type name in the command
-// usage (e.g., <mode: GameMode>). If an enum's options may change at runtime, implement the DynamicEnum
-// interface instead.
 type Enum interface {
 	// Type returns the type of the enum. This type shows up client-side in the command usage, in the spot
 	// where parameter types otherwise are.
@@ -42,15 +38,6 @@ type Enum interface {
 	// the argument passed to the enum parameter will be equal to one of these options. The provided Source
 	// can also be used to change the enums for each player.
 	Options(source Source) []string
-}
-
-// DynamicEnum is an optional interface that Enum implementations may implement to indicate that their
-// options can change at runtime. Enums implementing this interface will be sent as soft/dynamic enums,
-// allowing runtime updates.
-type DynamicEnum interface {
-	Enum
-	// Dynamic returns true if this enum's options may change at runtime.
-	Dynamic() bool
 }
 
 // ParamDescriber may be implemented by a Runnable to programmatically describe its parameters

--- a/server/session/command.go
+++ b/server/session/command.go
@@ -98,7 +98,16 @@ func (s *Session) sendAvailableCommands(co Controllable, softEnums map[string]st
 				} else {
 					t |= protocol.CommandArgValid
 					if len(enum.Options) > 0 || enum.Type != "" {
+						// cmd.Enum parameters are dynamic by nature (their options can vary per Source and over time),
+						// so they must be encoded as soft enums from the first AvailableCommands packet.
+						_, isCmdEnum := paramInfo.Value.(cmd.Enum)
+						if isCmdEnum && softEnums != nil {
+							softEnums[enum.Type] = struct{}{}
+						}
 						_, dynamic := softEnums[enum.Type]
+						if isCmdEnum {
+							dynamic = true
+						}
 						if !dynamic {
 							index, ok := enumIndices[enum.Type]
 							if !ok {

--- a/server/session/command.go
+++ b/server/session/command.go
@@ -213,7 +213,11 @@ func valueToParamType(i cmd.ParamInfo, source cmd.Source) (t uint32, enum comman
 // resendCommands resends all commands that a Session has access to if the map of runnable commands passed does not
 // match with the commands that the Session is currently allowed to execute.
 // True is returned if the commands were resent.
-func (s *Session) resendCommands(before map[string]map[int]cmd.Runnable, co Controllable, softEnums map[string]struct{}) (map[string]map[int]cmd.Runnable, bool) {
+func (s *Session) resendCommands(
+	before map[string]map[int]cmd.Runnable,
+	co Controllable,
+	softEnums map[string]struct{},
+) (map[string]map[int]cmd.Runnable, bool) {
 	commands := cmd.Commands()
 	m := make(map[string]map[int]cmd.Runnable, len(commands))
 
@@ -267,7 +271,13 @@ func (s *Session) enums(co Controllable) (map[string]cmd.Enum, map[string][]stri
 // resendEnums checks the options of the enums passed against the values that were previously recorded. If they do not
 // match, and the enum is in softEnums, the enum is resent via UpdateSoftEnum. If the enum is not yet in softEnums,
 // it is added and the full AvailableCommands packet is resent.
-func (s *Session) resendEnums(enums map[string]cmd.Enum, before map[string][]string, softEnums map[string]struct{}, r map[string]map[int]cmd.Runnable, c Controllable) map[string]map[int]cmd.Runnable {
+func (s *Session) resendEnums(
+	enums map[string]cmd.Enum,
+	before map[string][]string,
+	softEnums map[string]struct{},
+	r map[string]map[int]cmd.Runnable,
+	c Controllable,
+) map[string]map[int]cmd.Runnable {
 	for name, enum := range enums {
 		valuesBefore := before[name]
 		values := enum.Options(c)

--- a/server/session/command.go
+++ b/server/session/command.go
@@ -47,7 +47,7 @@ type translation interface {
 
 // sendAvailableCommands sends all available commands of the server. Once sent, they will be visible in the
 // /help list and will be auto-completed.
-func (s *Session) sendAvailableCommands(co Controllable) map[string]map[int]cmd.Runnable {
+func (s *Session) sendAvailableCommands(co Controllable, softEnums map[string]struct{}) map[string]map[int]cmd.Runnable {
 	commands := cmd.Commands()
 	m := make(map[string]map[int]cmd.Runnable, len(commands))
 
@@ -98,7 +98,8 @@ func (s *Session) sendAvailableCommands(co Controllable) map[string]map[int]cmd.
 				} else {
 					t |= protocol.CommandArgValid
 					if len(enum.Options) > 0 || enum.Type != "" {
-						if !enum.Dynamic {
+						_, dynamic := softEnums[enum.Type]
+						if !dynamic {
 							index, ok := enumIndices[enum.Type]
 							if !ok {
 								index = uint32(len(enums))
@@ -162,7 +163,6 @@ func (s *Session) sendAvailableCommands(co Controllable) map[string]map[int]cmd.
 type commandEnum struct {
 	Type    string
 	Options []string
-	Dynamic bool
 }
 
 // valueToParamType finds the command argument type of the value passed and returns it, in addition to creating
@@ -193,14 +193,9 @@ func valueToParamType(i cmd.ParamInfo, source cmd.Source) (t uint32, enum comman
 		}
 	}
 	if enum, ok := i.Value.(cmd.Enum); ok {
-		dynamic := false
-		if d, ok := i.Value.(cmd.DynamicEnum); ok {
-			dynamic = d.Dynamic()
-		}
 		return 0, commandEnum{
 			Type:    enum.Type(),
 			Options: enum.Options(source),
-			Dynamic: dynamic,
 		}
 	}
 	return protocol.CommandArgTypeValue, enum
@@ -209,7 +204,7 @@ func valueToParamType(i cmd.ParamInfo, source cmd.Source) (t uint32, enum comman
 // resendCommands resends all commands that a Session has access to if the map of runnable commands passed does not
 // match with the commands that the Session is currently allowed to execute.
 // True is returned if the commands were resent.
-func (s *Session) resendCommands(before map[string]map[int]cmd.Runnable, co Controllable) (map[string]map[int]cmd.Runnable, bool) {
+func (s *Session) resendCommands(before map[string]map[int]cmd.Runnable, co Controllable, softEnums map[string]struct{}) (map[string]map[int]cmd.Runnable, bool) {
 	commands := cmd.Commands()
 	m := make(map[string]map[int]cmd.Runnable, len(commands))
 
@@ -221,13 +216,13 @@ func (s *Session) resendCommands(before map[string]map[int]cmd.Runnable, co Cont
 		}
 	}
 	if len(before) != len(m) {
-		return s.sendAvailableCommands(co), true
+		return s.sendAvailableCommands(co, softEnums), true
 	}
 	// First check for commands that were newly added.
 	for name, r := range m {
 		for k := range r {
 			if _, ok := before[name][k]; !ok {
-				return s.sendAvailableCommands(co), true
+				return s.sendAvailableCommands(co, softEnums), true
 			}
 		}
 	}
@@ -235,7 +230,7 @@ func (s *Session) resendCommands(before map[string]map[int]cmd.Runnable, co Cont
 	for name, r := range before {
 		for k := range r {
 			if _, ok := m[name][k]; !ok {
-				return s.sendAvailableCommands(co), true
+				return s.sendAvailableCommands(co, softEnums), true
 			}
 		}
 	}
@@ -261,22 +256,35 @@ func (s *Session) enums(co Controllable) (map[string]cmd.Enum, map[string][]stri
 }
 
 // resendEnums checks the options of the enums passed against the values that were previously recorded. If they do not
-// match, the enum is resent to the client and the values are updated in the before map.
-func (s *Session) resendEnums(enums map[string]cmd.Enum, before map[string][]string, c Controllable) {
+// match, and the enum is in softEnums, the enum is resent via UpdateSoftEnum. If the enum is not yet in softEnums,
+// it is added and the full AvailableCommands packet is resent.
+func (s *Session) resendEnums(enums map[string]cmd.Enum, before map[string][]string, softEnums map[string]struct{}, r map[string]map[int]cmd.Runnable, c Controllable) map[string]map[int]cmd.Runnable {
 	for name, enum := range enums {
 		valuesBefore := before[name]
 		values := enum.Options(c)
 		before[name] = values
 
+		changed := false
 		if len(valuesBefore) != len(values) {
-			s.writePacket(&packet.UpdateSoftEnum{EnumType: name, Options: values, ActionType: packet.SoftEnumActionSet})
-			continue
-		}
-		for k, v := range values {
-			if valuesBefore[k] != v {
-				s.writePacket(&packet.UpdateSoftEnum{EnumType: name, Options: values, ActionType: packet.SoftEnumActionSet})
-				break
+			changed = true
+		} else {
+			for k, v := range values {
+				if valuesBefore[k] != v {
+					changed = true
+					break
+				}
 			}
 		}
+		if !changed {
+			continue
+		}
+
+		if _, dynamic := softEnums[name]; dynamic {
+			s.writePacket(&packet.UpdateSoftEnum{EnumType: name, Options: values, ActionType: packet.SoftEnumActionSet})
+		} else {
+			softEnums[name] = struct{}{}
+			r = s.sendAvailableCommands(c, softEnums)
+		}
 	}
+	return r
 }

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -368,13 +368,14 @@ func (s *Session) background() {
 		r          map[string]map[int]cmd.Runnable
 		enums      map[string]cmd.Enum
 		enumValues map[string][]string
+		softEnums  = make(map[string]struct{})
 		ok         bool
 		i          int
 	)
 
 	s.ent.ExecWorld(func(tx *world.Tx, e world.Entity) {
 		co := e.(Controllable)
-		r = s.sendAvailableCommands(co)
+		r = s.sendAvailableCommands(co, softEnums)
 		enums, enumValues = s.enums(co)
 	})
 
@@ -389,11 +390,11 @@ func (s *Session) background() {
 				if i++; i%20 == 0 {
 					// Enum resending happens relatively often and frequent updates are more important than with full
 					// command changes. Those are generally only related to permission changes, which doesn't happen often.
-					s.resendEnums(enums, enumValues, c)
+					r = s.resendEnums(enums, enumValues, softEnums, r, c)
 				}
 				if i%100 == 0 {
 					// Try to resend commands only every 5 seconds.
-					if r, ok = s.resendCommands(r, c); ok {
+					if r, ok = s.resendCommands(r, c, softEnums); ok {
 						enums, enumValues = s.enums(c)
 					}
 				}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces soft-enum handling for command parameters and streamlines enum updates without full command refreshes.
> 
> - Refactors `sendAvailableCommands`, `resendCommands`, and `resendEnums` to track `softEnums` and prefer `UpdateSoftEnum` when values change; falls back to resending `AvailableCommands` when first introducing a soft enum
> - Encodes `cmd.Enum` params as soft enums by default; adjusts param type flagging for suffixed vs. validated args
> - Normalizes boolean enum to `Boolean` with options `"true"`/`"false"`; removes `Dynamic` from `commandEnum`
> - Updates session background loop to initialize and propagate `softEnums` across resend cycles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 178b23d1e6160fa94a7c725453409735b8621415. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Command/update flow now supports dynamic ("soft") enums so available command options adapt without full refreshes.
* **Bug Fix**
  * Boolean parameter encoding normalized to "Boolean" with options ["true","false"].
  * Command argument validation and enum propagation improved to reduce incorrect or stale option lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->