### PR TITLE
perf: optimize light calculations

### DIFF
--- a/server/world/chunk/light.go
+++ b/server/world/chunk/light.go
@@ -1,16 +1,15 @@
 package chunk
 
 import (
-	"container/list"
 	"github.com/df-mc/dragonfly/server/block/cube"
 )
 
 // insertBlockLightNodes iterates over the chunk and looks for blocks that have a light level of at least 1.
 // If one is found, a node is added for it to the node queue.
-func (a *lightArea) insertBlockLightNodes(queue *list.List) {
+func (a *lightArea) insertBlockLightNodes(queue *lightQueue) {
 	a.iterSubChunks(anyLightBlocks, func(pos cube.Pos) {
 		if level := a.highest(pos, LightBlocks); level > 0 {
-			queue.PushBack(node(pos, level, BlockLight))
+			queue.push(node(pos, level, BlockLight))
 		}
 	})
 }
@@ -29,7 +28,7 @@ func anyLightBlocks(sub *SubChunk) bool {
 
 // insertSkyLightNodes iterates over the chunk and inserts a light node anywhere at the highest block in the
 // chunk. In addition, any skylight above those nodes will be set to 15.
-func (a *lightArea) insertSkyLightNodes(queue *list.List) {
+func (a *lightArea) insertSkyLightNodes(queue *lightQueue) {
 	a.iterHeightmap(func(x, z int, height, highestNeighbour, highestY, lowestY int) {
 		pos := cube.Pos{x, height, z}
 		if height <= a.r.Max() {
@@ -40,7 +39,7 @@ func (a *lightArea) insertSkyLightNodes(queue *list.List) {
 				if level := a.highest(pos.Sub(cube.Pos{0, 1}), FilteringBlocks); level != 15 && level != 0 {
 					// If we hit a block like water or leaves (something that diffuses but does not block light), we
 					// need a node above this block regardless of the neighbours.
-					queue.PushBack(node(pos, 15, SkyLight))
+					queue.push(node(pos, 15, SkyLight))
 				}
 			}
 		}
@@ -49,7 +48,7 @@ func (a *lightArea) insertSkyLightNodes(queue *list.List) {
 			// lower than the current one, on the same Y level, or one level higher, because light in
 			// this column can't spread below that anyway.
 			if pos[1]++; pos[1] < highestNeighbour {
-				queue.PushBack(node(pos, 15, SkyLight))
+				queue.push(node(pos, 15, SkyLight))
 				continue
 			}
 			// Fill the rest with full skylight.
@@ -60,7 +59,7 @@ func (a *lightArea) insertSkyLightNodes(queue *list.List) {
 
 // insertLightSpreadingNodes inserts light nodes into the node queue passed which, when propagated, will
 // spread into the neighbouring chunks.
-func (a *lightArea) insertLightSpreadingNodes(queue *list.List, lt light) {
+func (a *lightArea) insertLightSpreadingNodes(queue *lightQueue, lt light) {
 	a.iterEdges(a.nodesNeeded(lt), func(pa, pb cube.Pos) {
 		la, lb := a.light(pa, lt), a.light(pb, lt)
 		if la == lb || la-1 == lb || lb-1 == la {
@@ -68,9 +67,9 @@ func (a *lightArea) insertLightSpreadingNodes(queue *list.List, lt light) {
 			return
 		}
 		if filter := a.highest(pb, FilteringBlocks) + 1; la > filter && la-filter > lb {
-			queue.PushBack(node(pb, la-filter, lt))
+			queue.push(node(pb, la-filter, lt))
 		} else if filter = a.highest(pa, FilteringBlocks) + 1; lb > filter && lb-filter > la {
-			queue.PushBack(node(pa, lb-filter, lt))
+			queue.push(node(pa, lb-filter, lt))
 		}
 	})
 }
@@ -91,19 +90,33 @@ func (a *lightArea) nodesNeeded(lt light) func(sa, sb *SubChunk) bool {
 
 // propagate spreads the next light node in the node queue passed through the lightArea a. propagate adds the neighbours
 // of the node to the queue for as long as it is able to spread.
-func (a *lightArea) propagate(queue *list.List) {
-	n := queue.Remove(queue.Front()).(lightNode)
+func (a *lightArea) propagate(queue *lightQueue) {
+	n, ok := queue.pop()
+	if !ok {
+		return
+	}
 	if a.light(n.pos, n.lt) >= n.level {
 		return
 	}
 	a.setLight(n.pos, n.lt, n.level)
 
-	for neighbour := range a.neighbours(n) {
-		filter := a.highest(neighbour.pos, FilteringBlocks) + 1
-		if n.level > filter && a.light(neighbour.pos, n.lt) < n.level-filter {
-			neighbour.level = n.level - filter
-			queue.PushBack(neighbour)
-		}
+	x, y, z := n.pos[0], n.pos[1], n.pos[2]
+	a.propagateNeighbour(queue, n.lt, n.level, x+1, y, z)
+	a.propagateNeighbour(queue, n.lt, n.level, x-1, y, z)
+	a.propagateNeighbour(queue, n.lt, n.level, x, y+1, z)
+	a.propagateNeighbour(queue, n.lt, n.level, x, y-1, z)
+	a.propagateNeighbour(queue, n.lt, n.level, x, y, z+1)
+	a.propagateNeighbour(queue, n.lt, n.level, x, y, z-1)
+}
+
+func (a *lightArea) propagateNeighbour(queue *lightQueue, lt light, level uint8, x, y, z int) {
+	if y < a.r.Min() || y > a.r.Max() || x < a.baseX || z < a.baseZ || x >= a.baseX+a.w*16 || z >= a.baseZ+a.w*16 {
+		return
+	}
+	pos := cube.Pos{x, y, z}
+	filter := a.highest(pos, FilteringBlocks) + 1
+	if level > filter && a.light(pos, lt) < level-filter {
+		queue.push(node(pos, level-filter, lt))
 	}
 }
 

--- a/server/world/chunk/light_area.go
+++ b/server/world/chunk/light_area.go
@@ -14,6 +14,7 @@ type lightArea struct {
 	r            cube.Range
 }
 
+// lightQueue is a FIFO ring buffer used during light propagation.
 type lightQueue struct {
 	nodes []lightNode
 	head  int
@@ -21,6 +22,7 @@ type lightQueue struct {
 	size  int
 }
 
+// newLightQueue creates an empty queue sized to capacity (at least 1).
 func newLightQueue(capacity int) *lightQueue {
 	if capacity < 1 {
 		capacity = 1
@@ -28,6 +30,7 @@ func newLightQueue(capacity int) *lightQueue {
 	return &lightQueue{nodes: make([]lightNode, capacity)}
 }
 
+// push appends a node to the tail, growing storage if full.
 func (q *lightQueue) push(n lightNode) {
 	if q.size == len(q.nodes) {
 		q.grow()
@@ -37,6 +40,7 @@ func (q *lightQueue) push(n lightNode) {
 	q.size++
 }
 
+// pop removes and returns the oldest queued node.
 func (q *lightQueue) pop() (lightNode, bool) {
 	if q.size == 0 {
 		return lightNode{}, false
@@ -47,10 +51,12 @@ func (q *lightQueue) pop() (lightNode, bool) {
 	return n, true
 }
 
+// empty returns true when no nodes are queued.
 func (q *lightQueue) empty() bool {
 	return q.size == 0
 }
 
+// grow expands the ring buffer and reorders elements to start at index 0.
 func (q *lightQueue) grow() {
 	nodes := make([]lightNode, len(q.nodes)<<1)
 	if q.head < q.tail {

--- a/server/world/chunk/light_area.go
+++ b/server/world/chunk/light_area.go
@@ -2,9 +2,7 @@ package chunk
 
 import (
 	"bytes"
-	"container/list"
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"iter"
 	"math"
 )
 
@@ -14,6 +12,56 @@ type lightArea struct {
 	c            []*Chunk
 	w            int
 	r            cube.Range
+}
+
+type lightQueue struct {
+	nodes []lightNode
+	head  int
+	tail  int
+	size  int
+}
+
+func newLightQueue(capacity int) *lightQueue {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &lightQueue{nodes: make([]lightNode, capacity)}
+}
+
+func (q *lightQueue) push(n lightNode) {
+	if q.size == len(q.nodes) {
+		q.grow()
+	}
+	q.nodes[q.tail] = n
+	q.tail = (q.tail + 1) % len(q.nodes)
+	q.size++
+}
+
+func (q *lightQueue) pop() (lightNode, bool) {
+	if q.size == 0 {
+		return lightNode{}, false
+	}
+	n := q.nodes[q.head]
+	q.head = (q.head + 1) % len(q.nodes)
+	q.size--
+	return n, true
+}
+
+func (q *lightQueue) empty() bool {
+	return q.size == 0
+}
+
+func (q *lightQueue) grow() {
+	nodes := make([]lightNode, len(q.nodes)<<1)
+	if q.head < q.tail {
+		copy(nodes, q.nodes[q.head:q.tail])
+	} else {
+		n := copy(nodes, q.nodes[q.head:])
+		copy(nodes[n:], q.nodes[:q.tail])
+	}
+	q.head = 0
+	q.tail = q.size
+	q.nodes = nodes
 }
 
 // LightArea creates a lightArea with the lower corner of the lightArea at baseX and baseY. The length of the Chunk
@@ -30,11 +78,11 @@ func LightArea(c []*Chunk, baseX, baseY int) *lightArea {
 // individual chunks within the lightArea itself, without light crossing chunk borders.
 func (a *lightArea) Fill() {
 	a.initialiseLightSlices()
-	queue := list.New()
+	queue := newLightQueue(512)
 	a.insertBlockLightNodes(queue)
 	a.insertSkyLightNodes(queue)
 
-	for queue.Len() != 0 {
+	for !queue.empty() {
 		a.propagate(queue)
 	}
 }
@@ -43,11 +91,11 @@ func (a *lightArea) Fill() {
 // neighbouring chunks. The neighbouring chunks must have passed the light 'filling' stage before this
 // function is called for an lightArea that includes them.
 func (a *lightArea) Spread() {
-	queue := list.New()
+	queue := newLightQueue(512)
 	a.insertLightSpreadingNodes(queue, BlockLight)
 	a.insertLightSpreadingNodes(queue, SkyLight)
 
-	for queue.Len() != 0 {
+	for !queue.empty() {
 		a.propagate(queue)
 	}
 }
@@ -60,21 +108,6 @@ func (a *lightArea) light(pos cube.Pos, l light) uint8 {
 // light sets the light at a cube.Pos with the light type l.
 func (a *lightArea) setLight(pos cube.Pos, l light, v uint8) {
 	l.setLight(a.sub(pos), uint8(pos[0]&0xf), uint8(pos[1]&0xf), uint8(pos[2]&0xf), v)
-}
-
-// neighbours returns all neighbour lightNode of the one passed. If one of these nodes would otherwise fall outside the
-// lightArea, it is not returned.
-func (a *lightArea) neighbours(n lightNode) iter.Seq[lightNode] {
-	return func(yield func(lightNode) bool) {
-		for _, f := range cube.Faces() {
-			nn := lightNode{pos: n.pos.Side(f), lt: n.lt}
-			if nn.pos[1] <= a.r.Max() && nn.pos[1] >= a.r.Min() && nn.pos[0] >= a.baseX && nn.pos[2] >= a.baseZ && nn.pos[0] < a.baseX+a.w*16 && nn.pos[2] < a.baseZ+a.w*16 {
-				if !yield(nn) {
-					return
-				}
-			}
-		}
-	}
 }
 
 // iterSubChunks iterates over all blocks of the lightArea on a per-SubChunk basis. A filter function may be passed to

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -1158,7 +1158,8 @@ func (w *World) chunk(pos ChunkPos) *Column {
 		return c
 	}
 	c, err := w.loadChunk(pos)
-	chunk.LightArea([]*chunk.Chunk{c.Chunk}, int(pos[0]), int(pos[1])).Fill()
+	single := [1]*chunk.Chunk{c.Chunk}
+	chunk.LightArea(single[:], int(pos[0]), int(pos[1])).Fill()
 	if err != nil {
 		w.conf.Log.Error("load chunk: "+err.Error(), "X", pos[0], "Z", pos[1])
 		return c
@@ -1213,7 +1214,8 @@ func (w *World) calculateLight(centre ChunkPos) {
 // spreadLight spreads the light from the chunk passed at the position passed
 // to all neighbours if each of them is loaded.
 func (w *World) spreadLight(pos ChunkPos) {
-	c := make([]*chunk.Chunk, 0, 9)
+	var chunks [9]*chunk.Chunk
+	i := 0
 	for z := int32(-1); z <= 1; z++ {
 		for x := int32(-1); x <= 1; x++ {
 			neighbour, ok := w.chunks[ChunkPos{pos[0] + x, pos[1] + z}]
@@ -1221,11 +1223,12 @@ func (w *World) spreadLight(pos ChunkPos) {
 				// Not all surrounding chunks existed: Stop spreading light.
 				return
 			}
-			c = append(c, neighbour.Chunk)
+			chunks[i] = neighbour.Chunk
+			i++
 		}
 	}
 	// All chunks surrounding the current one are present, so we can spread.
-	chunk.LightArea(c, int(pos[0])-1, int(pos[1])-1).Spread()
+	chunk.LightArea(chunks[:], int(pos[0])-1, int(pos[1])-1).Spread()
 }
 
 // autoSave runs until the world is running, saving and removing chunks that

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -1158,8 +1158,7 @@ func (w *World) chunk(pos ChunkPos) *Column {
 		return c
 	}
 	c, err := w.loadChunk(pos)
-	single := [1]*chunk.Chunk{c.Chunk}
-	chunk.LightArea(single[:], int(pos[0]), int(pos[1])).Fill()
+	chunk.LightArea([]*chunk.Chunk{c.Chunk}, int(pos[0]), int(pos[1])).Fill()
 	if err != nil {
 		w.conf.Log.Error("load chunk: "+err.Error(), "X", pos[0], "Z", pos[1])
 		return c
@@ -1214,8 +1213,7 @@ func (w *World) calculateLight(centre ChunkPos) {
 // spreadLight spreads the light from the chunk passed at the position passed
 // to all neighbours if each of them is loaded.
 func (w *World) spreadLight(pos ChunkPos) {
-	var chunks [9]*chunk.Chunk
-	i := 0
+	c := make([]*chunk.Chunk, 0, 9)
 	for z := int32(-1); z <= 1; z++ {
 		for x := int32(-1); x <= 1; x++ {
 			neighbour, ok := w.chunks[ChunkPos{pos[0] + x, pos[1] + z}]
@@ -1223,12 +1221,11 @@ func (w *World) spreadLight(pos ChunkPos) {
 				// Not all surrounding chunks existed: Stop spreading light.
 				return
 			}
-			chunks[i] = neighbour.Chunk
-			i++
+			c = append(c, neighbour.Chunk)
 		}
 	}
 	// All chunks surrounding the current one are present, so we can spread.
-	chunk.LightArea(chunks[:], int(pos[0])-1, int(pos[1])-1).Spread()
+	chunk.LightArea(c, int(pos[0])-1, int(pos[1])-1).Spread()
 }
 
 // autoSave runs until the world is running, saving and removing chunks that


### PR DESCRIPTION
- Replaced linked-list BFS queue with a ring-buffer queue for light propagation (Fill/Spread) to remove per-node heap churn.
- Removed iterator-based neighbor traversal in propagation; now uses direct 6-neighbor checks.
- Removed small slice allocations in world light orchestration (chunk() and spreadLight()).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled light propagation internals for better performance and more consistent lighting.
  * Reworked queue handling and neighbor processing to reduce stalls and memory overhead during chunk updates.
  * Added stricter boundary checks to minimize lighting artifacts at chunk edges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lighting propagation logic and queue semantics; while changes are performance-motivated, subtle ordering/bounds differences could cause lighting artifacts or edge-case regressions.
> 
> **Overview**
> Optimizes chunk light propagation by replacing the `container/list` BFS queue with a custom ring-buffer `lightQueue`, reducing allocations during `Fill`/`Spread`.
> 
> Refactors `propagate` to avoid iterator-based neighbour enumeration, instead doing direct 6-direction checks via `propagateNeighbour` with explicit bounds filtering before enqueuing new light nodes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc21a092d73b2f31dc080edd6269a0df5818e85f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->