### PR TITLE
feat(NBT): implement item lock

### DIFF
--- a/server/internal/nbtconv/item_lock.go
+++ b/server/internal/nbtconv/item_lock.go
@@ -1,0 +1,68 @@
+package nbtconv
+
+import "github.com/df-mc/dragonfly/server/item"
+
+const (
+	itemLockKey       = "minecraft:item_lock"
+	legacyItemLockKey = "item_lock"
+	itemLockModeKey   = "mode"
+)
+
+// readItemLock reads the Bedrock item_lock component from the item NBT and saves it to the stack.
+func readItemLock(m map[string]any, s *item.Stack) {
+	mode, ok := lockModeFromMap(m)
+	if !ok {
+		return
+	}
+	*s = s.WithLockMode(mode)
+}
+
+// writeItemLock writes the Bedrock item_lock component to the item NBT if one is present on the stack.
+func writeItemLock(m map[string]any, s item.Stack) {
+	if !s.Locked() {
+		return
+	}
+	v := s.LockMode().LegacyValue()
+	m[itemLockKey] = v
+}
+
+func lockModeFromMap(m map[string]any) (item.LockMode, bool) {
+	if mode, ok := lockModeFromValue(m[itemLockKey]); ok {
+		return mode, true
+	}
+	return lockModeFromValue(m[legacyItemLockKey])
+}
+
+func lockModeFromValue(v any) (item.LockMode, bool) {
+	switch v := v.(type) {
+	case map[string]any:
+		mode, _ := v[itemLockModeKey].(string)
+		return item.ParseLockMode(mode)
+	case uint8:
+		return item.LockModeFromLegacyValue(v)
+	case int8:
+		if v < 0 {
+			return item.NotLocked, false
+		}
+		return item.LockModeFromLegacyValue(uint8(v))
+	case int16:
+		if v < 0 || v > 255 {
+			return item.NotLocked, false
+		}
+		return item.LockModeFromLegacyValue(uint8(v))
+	case int32:
+		if v < 0 || v > 255 {
+			return item.NotLocked, false
+		}
+		return item.LockModeFromLegacyValue(uint8(v))
+	case int64:
+		if v < 0 || v > 255 {
+			return item.NotLocked, false
+		}
+		return item.LockModeFromLegacyValue(uint8(v))
+	case string:
+		return item.ParseLockMode(v)
+	default:
+		return item.NotLocked, false
+	}
+}

--- a/server/internal/nbtconv/read.go
+++ b/server/internal/nbtconv/read.go
@@ -3,12 +3,13 @@ package nbtconv
 import (
 	"bytes"
 	"encoding/gob"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
 	"golang.org/x/exp/constraints"
-	"time"
 )
 
 // Bool reads a uint8 value from a map at key k and returns true if it equals 1.
@@ -166,6 +167,7 @@ func Item(data map[string]any, s *item.Stack) item.Stack {
 	readDisplay(tag, s)
 	readDragonflyData(tag, s)
 	readEnchantments(tag, s)
+	readItemLock(tag, s)
 	readUnbreakable(tag, s)
 	return *s
 }

--- a/server/internal/nbtconv/write.go
+++ b/server/internal/nbtconv/write.go
@@ -3,10 +3,11 @@ package nbtconv
 import (
 	"bytes"
 	"encoding/gob"
+	"sort"
+
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/chunk"
-	"sort"
 )
 
 // WriteItem encodes an item stack into a map that can be encoded using NBT.
@@ -25,6 +26,7 @@ func WriteItem(s item.Stack, disk bool) map[string]any {
 	writeDisplay(tag, s)
 	writeDragonflyData(tag, s)
 	writeEnchantments(tag, s)
+	writeItemLock(tag, s)
 	writeUnbreakable(tag, s)
 
 	data := make(map[string]any)

--- a/server/item/lock.go
+++ b/server/item/lock.go
@@ -1,0 +1,62 @@
+package item
+
+// LockMode describes the Bedrock item_lock mode applied to an item stack.
+type LockMode uint8
+
+const (
+	// NotLocked indicates no item_lock is applied to the stack.
+	NotLocked LockMode = iota
+	// LockInInventory prevents the stack from being removed from the player's inventory, dropped, crafted with,
+	// placed in bundles, or renamed in an anvil.
+	LockInInventory
+	// LockInSlot prevents the stack from being moved or removed from its current slot in the player's inventory.
+	LockInSlot
+)
+
+// String returns the Bedrock component mode name of the lock mode.
+func (m LockMode) String() string {
+	switch m {
+	case LockInInventory:
+		return "lock_in_inventory"
+	case LockInSlot:
+		return "lock_in_slot"
+	default:
+		return ""
+	}
+}
+
+// ParseLockMode parses a Bedrock item_lock mode string.
+func ParseLockMode(mode string) (LockMode, bool) {
+	switch mode {
+	case "lock_in_inventory":
+		return LockInInventory, true
+	case "lock_in_slot":
+		return LockInSlot, true
+	default:
+		return NotLocked, false
+	}
+}
+
+// LockModeFromLegacyValue parses Bedrock's legacy item_lock byte value.
+func LockModeFromLegacyValue(v uint8) (LockMode, bool) {
+	switch v {
+	case 1:
+		return LockInSlot, true
+	case 2:
+		return LockInInventory, true
+	default:
+		return NotLocked, false
+	}
+}
+
+// LegacyValue returns the Bedrock item NBT byte used to represent the lock mode.
+func (m LockMode) LegacyValue() uint8 {
+	switch m {
+	case LockInSlot:
+		return 1
+	case LockInInventory:
+		return 2
+	default:
+		return 0
+	}
+}

--- a/server/item/stack.go
+++ b/server/item/stack.go
@@ -25,6 +25,7 @@ type Stack struct {
 
 	damage      int
 	unbreakable bool
+	lockMode    LockMode
 
 	anvilCost int
 
@@ -167,6 +168,28 @@ func (s Stack) AsBreakable() Stack {
 		return s
 	}
 	s.unbreakable = false
+	return s
+}
+
+// LockMode returns the Bedrock item_lock mode applied to the stack.
+func (s Stack) LockMode() LockMode {
+	return s.lockMode
+}
+
+// Locked reports if the stack has an item_lock mode applied.
+func (s Stack) Locked() bool {
+	return s.lockMode != NotLocked
+}
+
+// WithLockMode returns a copy of the stack with the Bedrock item_lock mode applied.
+func (s Stack) WithLockMode(mode LockMode) Stack {
+	s.lockMode = mode
+	return s
+}
+
+// WithoutLock returns a copy of the stack without an item_lock mode applied.
+func (s Stack) WithoutLock() Stack {
+	s.lockMode = NotLocked
 	return s
 }
 
@@ -346,7 +369,8 @@ func (s Stack) WithItem(t world.Item) Stack {
 		WithCustomName(s.customName).
 		WithLore(s.lore...).
 		WithEnchantments(s.Enchantments()...).
-		WithAnvilCost(s.anvilCost)
+		WithAnvilCost(s.anvilCost).
+		WithLockMode(s.lockMode)
 	cp.unbreakable = s.unbreakable && s.MaxDurability() != -1
 	cp.data = s.data
 	return cp
@@ -395,6 +419,9 @@ func (s Stack) Comparable(s2 Stack) bool {
 	if name != name2 || meta != meta2 || s.anvilCost != s2.anvilCost || s.customName != s2.customName {
 		return false
 	}
+	if s.lockMode != s2.lockMode {
+		return false
+	}
 	for !slices.Equal(s.lore, s2.lore) {
 		return false
 	}
@@ -421,7 +448,7 @@ func (s Stack) String() string {
 	if s.item == nil {
 		return fmt.Sprintf("Stack<nil> x%v", s.count)
 	}
-	return fmt.Sprintf("Stack<%T%+v>(custom name='%v', lore='%v', damage=%v, anvilCost=%v) x%v", s.item, s.item, s.customName, s.lore, s.damage, s.anvilCost, s.count)
+	return fmt.Sprintf("Stack<%T%+v>(custom name='%v', lore='%v', damage=%v, anvilCost=%v, lockMode=%q) x%v", s.item, s.item, s.customName, s.lore, s.damage, s.anvilCost, s.lockMode.String(), s.count)
 }
 
 // Values returns all values associated with the stack by users. The map returned is a copy of the original:

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2138,11 +2138,15 @@ func (p *Player) PickBlock(pos cube.Pos) {
 	if p.Handler().HandleBlockPick(ctx, pos, b); ctx.Cancelled() {
 		return
 	}
-	_, offhand := p.HeldItems()
+	held, offhand := p.HeldItems()
 
 	if found {
+		foundItem, _ := p.Inventory().Item(slot)
 		if slot < 9 {
 			_ = p.SetHeldSlot(slot)
+			return
+		}
+		if held.LockMode() == item.LockInSlot || foundItem.LockMode() == item.LockInSlot {
 			return
 		}
 		_ = p.Inventory().Swap(slot, int(*p.heldSlot))
@@ -2151,12 +2155,18 @@ func (p *Player) PickBlock(pos cube.Pos) {
 
 	firstEmpty, emptyFound := p.Inventory().FirstEmpty()
 	if !emptyFound {
+		if held.Locked() {
+			return
+		}
 		p.SetHeldItems(pickedItem, offhand)
 		return
 	}
 	if firstEmpty < 9 {
 		_ = p.SetHeldSlot(firstEmpty)
 		_ = p.Inventory().SetItem(firstEmpty, pickedItem)
+		return
+	}
+	if held.LockMode() == item.LockInSlot {
 		return
 	}
 	_ = p.Inventory().Swap(firstEmpty, int(*p.heldSlot))
@@ -3185,6 +3195,9 @@ func (p *Player) useContext() *item.UseContext {
 			src, dst, srcInv, dstInv := int(*p.heldSlot), i, p.inv, p.armour.Inventory()
 			srcIt, _ := srcInv.Item(src)
 			dstIt, _ := dstInv.Item(dst)
+			if srcIt.LockMode() == item.LockInSlot || dstIt.LockMode() == item.LockInSlot {
+				return
+			}
 
 			ctx := event.C(inventory.Holder(p))
 			_ = call(ctx, src, srcIt, srcInv.Handler().HandleTake)

--- a/server/session/handler_anvil.go
+++ b/server/session/handler_anvil.go
@@ -39,6 +39,9 @@ func (h *ItemStackRequestHandler) handleCraftRecipeOptional(a *protocol.CraftRec
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerAnvilInput},
 		Slot:      anvilInputSlot,
 	}, s, tx)
+	if err := ensureUnlockedForAnvil(input); err != nil {
+		return err
+	}
 	if input.Empty() {
 		return fmt.Errorf("no item in input input slot")
 	}
@@ -46,6 +49,11 @@ func (h *ItemStackRequestHandler) handleCraftRecipeOptional(a *protocol.CraftRec
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerAnvilMaterial},
 		Slot:      anvilMaterialSlot,
 	}, s, tx)
+	if !material.Empty() {
+		if err := ensureUnlockedForAnvil(material); err != nil {
+			return err
+		}
+	}
 	result := input
 
 	// The sum of the input's anvil cost as well as the material's anvil cost.

--- a/server/session/handler_crafting.go
+++ b/server/session/handler_crafting.go
@@ -2,14 +2,15 @@ package session
 
 import (
 	"fmt"
+	"math"
+	"slices"
+
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/item/creative"
 	"github.com/df-mc/dragonfly/server/item/inventory"
 	"github.com/df-mc/dragonfly/server/item/recipe"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
-	"math"
-	"slices"
 )
 
 // handleCraft handles the CraftRecipe request action.
@@ -37,7 +38,10 @@ func (h *ItemStackRequestHandler) handleCraft(a *protocol.CraftRecipeStackReques
 	offset := s.craftingOffset()
 	consumed := make([]bool, size)
 	for _, expected := range craft.Input() {
-		var processed bool
+		var (
+			processed bool
+			lockedErr error
+		)
 		for slot := offset; slot < offset+size; slot++ {
 			if consumed[slot-offset] {
 				// We've already consumed this slot, skip it.
@@ -52,6 +56,10 @@ func (h *ItemStackRequestHandler) handleCraft(a *protocol.CraftRecipeStackReques
 				// Not the same item.
 				continue
 			}
+			if err := ensureUnlockedForCrafting(has); err != nil {
+				lockedErr = err
+				continue
+			}
 			processed, consumed[slot-offset] = true, true
 			st := has.Grow(-expected.Count() * timesCrafted)
 			h.setItemInSlot(protocol.StackRequestSlotInfo{
@@ -61,6 +69,9 @@ func (h *ItemStackRequestHandler) handleCraft(a *protocol.CraftRecipeStackReques
 			break
 		}
 		if !processed {
+			if lockedErr != nil {
+				return lockedErr
+			}
 			return fmt.Errorf("recipe %v: could not consume expected item: %v", a.RecipeNetworkID, expected)
 		}
 	}
@@ -106,6 +117,7 @@ func (h *ItemStackRequestHandler) handleAutoCraft(a *protocol.AutoCraftRecipeSta
 
 	for _, expected := range flattenedInputs {
 		remaining := expected.Count() * timesCrafted
+		var lockedErr error
 
 		for id, inv := range map[byte]*inventory.Inventory{
 			protocol.ContainerCraftingInput:              s.ui,
@@ -118,6 +130,10 @@ func (h *ItemStackRequestHandler) handleAutoCraft(a *protocol.AutoCraftRecipeSta
 				}
 				if !matchingStacks(has, expected) {
 					// Not the same item.
+					continue
+				}
+				if err := ensureUnlockedForCrafting(has); err != nil {
+					lockedErr = err
 					continue
 				}
 
@@ -143,6 +159,9 @@ func (h *ItemStackRequestHandler) handleAutoCraft(a *protocol.AutoCraftRecipeSta
 			}
 		}
 		if remaining != 0 {
+			if lockedErr != nil {
+				return lockedErr
+			}
 			return fmt.Errorf("recipe %v: could not consume expected item: %v", a.RecipeNetworkID, expected)
 		}
 	}
@@ -296,6 +315,9 @@ func (h *ItemStackRequestHandler) tryDynamicCraft(s *Session, tx *world.Tx, time
 			slot := offset + i
 			it, _ := s.ui.Item(int(slot))
 			if !it.Empty() {
+				if err := ensureUnlockedForCrafting(it); err != nil {
+					return err
+				}
 				// Consume one item from this slot per craft
 				st := it.Grow(-1 * timesCrafted)
 				h.setItemInSlot(protocol.StackRequestSlotInfo{

--- a/server/session/handler_grindstone.go
+++ b/server/session/handler_grindstone.go
@@ -2,9 +2,10 @@ package session
 
 import (
 	"fmt"
-	"github.com/df-mc/dragonfly/server/world"
 	"math"
 	"math/rand/v2"
+
+	"github.com/df-mc/dragonfly/server/world"
 
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/entity"
@@ -34,10 +35,20 @@ func (h *ItemStackRequestHandler) handleGrindstoneCraft(s *Session, tx *world.Tx
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerGrindstoneInput},
 		Slot:      grindstoneFirstInputSlot,
 	}, s, tx)
+	if !firstInput.Empty() {
+		if err := ensureUnlockedForCrafting(firstInput); err != nil {
+			return err
+		}
+	}
 	secondInput, _ := h.itemInSlot(protocol.StackRequestSlotInfo{
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerGrindstoneAdditional},
 		Slot:      grindstoneSecondInputSlot,
 	}, s, tx)
+	if !secondInput.Empty() {
+		if err := ensureUnlockedForCrafting(secondInput); err != nil {
+			return err
+		}
+	}
 	if firstInput.Empty() && secondInput.Empty() {
 		return fmt.Errorf("input item(s) are empty")
 	}

--- a/server/session/handler_inventory_transaction.go
+++ b/server/session/handler_inventory_transaction.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/item"
@@ -119,6 +120,12 @@ func (h *InventoryTransactionHandler) handleNormalTransaction(pk *packet.Invento
 	}
 	if !expected.Equal(actual) {
 		return fmt.Errorf("different item thrown than held in slot: %#v was thrown but held %#v", expected, actual)
+	}
+	if err := ensureUnlockedForInventoryRemoval(actual, protocol.StackRequestSlotInfo{
+		Container: protocol.FullContainerName{ContainerID: protocol.ContainerInventory},
+		Slot:      byte(slot),
+	}); err != nil {
+		return err
 	}
 
 	// Explicitly don't re-use the thrown variable. This item was supplied by the user, and if some

--- a/server/session/handler_item_stack_request.go
+++ b/server/session/handler_item_stack_request.go
@@ -2,6 +2,9 @@ package session
 
 import (
 	"fmt"
+	"math"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/entity"
 	"github.com/df-mc/dragonfly/server/event"
@@ -10,8 +13,6 @@ import (
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
-	"math"
-	"time"
 )
 
 // ItemStackRequestHandler handles the ItemStackRequest packet. It handles the actions done within the
@@ -147,6 +148,9 @@ func (h *ItemStackRequestHandler) handleTransfer(from, to protocol.StackRequestS
 	}
 	i, _ := h.itemInSlot(from, s, tx)
 	dest, _ := h.itemInSlot(to, s, tx)
+	if err := ensureUnlockedForInventoryMove(i, from, to, s, tx); err != nil {
+		return err
+	}
 	if !i.Comparable(dest) {
 		return fmt.Errorf("client tried transferring %v to %v, but the stacks are incomparable", i, dest)
 	}
@@ -183,6 +187,12 @@ func (h *ItemStackRequestHandler) handleSwap(a *protocol.SwapStackRequestAction,
 	}
 	i, _ := h.itemInSlot(a.Source, s, tx)
 	dest, _ := h.itemInSlot(a.Destination, s, tx)
+	if err := ensureUnlockedForInventoryMove(i, a.Source, a.Destination, s, tx); err != nil {
+		return err
+	}
+	if err := ensureUnlockedForInventoryMove(dest, a.Destination, a.Source, s, tx); err != nil {
+		return err
+	}
 
 	invA, _ := s.invByID(int32(a.Source.Container.ContainerID), tx)
 	invB, _ := s.invByID(int32(a.Destination.Container.ContainerID), tx)
@@ -227,6 +237,9 @@ func (h *ItemStackRequestHandler) handleDestroy(a *protocol.DestroyStackRequestA
 		return fmt.Errorf("source slot out of sync: %w", err)
 	}
 	i, _ := h.itemInSlot(a.Source, s, tx)
+	if err := ensureUnlockedForInventoryRemoval(i, a.Source); err != nil {
+		return err
+	}
 	if i.Count() < int(a.Count) {
 		return fmt.Errorf("client attempted to destroy %v items, but only %v present", a.Count, i.Count())
 	}
@@ -242,6 +255,9 @@ func (h *ItemStackRequestHandler) handleDrop(a *protocol.DropStackRequestAction,
 		return fmt.Errorf("source slot out of sync: %w", err)
 	}
 	i, _ := h.itemInSlot(a.Source, s, tx)
+	if err := ensureUnlockedForInventoryRemoval(i, a.Source); err != nil {
+		return err
+	}
 	if i.Count() < int(a.Count) {
 		return fmt.Errorf("client attempted to drop %v items, but only %v present", a.Count, i.Count())
 	}

--- a/server/session/handler_loom.go
+++ b/server/session/handler_loom.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
@@ -33,6 +34,9 @@ func (h *ItemStackRequestHandler) handleLoomCraft(a *protocol.CraftLoomRecipeSta
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerLoomInput},
 		Slot:      loomInputSlot,
 	}, s, tx)
+	if err := ensureUnlockedForCrafting(input); err != nil {
+		return err
+	}
 	if input.Count() < timesCrafted {
 		return fmt.Errorf("input item count is less than times crafted")
 	}
@@ -49,6 +53,9 @@ func (h *ItemStackRequestHandler) handleLoomCraft(a *protocol.CraftLoomRecipeSta
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerLoomDye},
 		Slot:      loomDyeSlot,
 	}, s, tx)
+	if err := ensureUnlockedForCrafting(dye); err != nil {
+		return err
+	}
 	if dye.Count() < timesCrafted {
 		return fmt.Errorf("dye item count is less than times crafted")
 	}
@@ -67,6 +74,11 @@ func (h *ItemStackRequestHandler) handleLoomCraft(a *protocol.CraftLoomRecipeSta
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerLoomMaterial},
 		Slot:      loomPatternSlot,
 	}, s, tx)
+	if !pattern.Empty() {
+		if err := ensureUnlockedForCrafting(pattern); err != nil {
+			return err
+		}
+	}
 	if expectedPatternItem, hasPatternItem := expectedPattern.Item(); hasPatternItem {
 		if pattern.Empty() {
 			return fmt.Errorf("pattern item is empty but the pattern is required")

--- a/server/session/handler_smithing.go
+++ b/server/session/handler_smithing.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/item/recipe"
 	"github.com/df-mc/dragonfly/server/world"
@@ -39,6 +40,9 @@ func (h *ItemStackRequestHandler) handleSmithing(a *protocol.CraftRecipeStackReq
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerSmithingTableInput},
 		Slot:      smithingInputSlot,
 	}, s, tx)
+	if err := ensureUnlockedForCrafting(input); err != nil {
+		return err
+	}
 	if !matchingStacks(input, expectedInputs[0]) {
 		return fmt.Errorf("input item is not the same as expected input")
 	}
@@ -46,6 +50,9 @@ func (h *ItemStackRequestHandler) handleSmithing(a *protocol.CraftRecipeStackReq
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerSmithingTableMaterial},
 		Slot:      smithingMaterialSlot,
 	}, s, tx)
+	if err := ensureUnlockedForCrafting(material); err != nil {
+		return err
+	}
 	if !matchingStacks(material, expectedInputs[1]) {
 		return fmt.Errorf("material item is not the same as expected material")
 	}
@@ -53,6 +60,9 @@ func (h *ItemStackRequestHandler) handleSmithing(a *protocol.CraftRecipeStackReq
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerSmithingTableTemplate},
 		Slot:      smithingTemplateSlot,
 	}, s, tx)
+	if err := ensureUnlockedForCrafting(template); err != nil {
+		return err
+	}
 	if !matchingStacks(template, expectedInputs[2]) {
 		return fmt.Errorf("template item is not the same as expected template")
 	}

--- a/server/session/handler_stonecutter.go
+++ b/server/session/handler_stonecutter.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+
 	"github.com/df-mc/dragonfly/server/item/recipe"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
@@ -33,6 +34,9 @@ func (h *ItemStackRequestHandler) handleStonecutting(a *protocol.CraftRecipeStac
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerStonecutterInput},
 		Slot:      stonecutterInputSlot,
 	}, s, tx)
+	if err := ensureUnlockedForCrafting(input); err != nil {
+		return err
+	}
 	if input.Count() < timesCrafted {
 		return fmt.Errorf("input item count is less than number of crafts")
 	}

--- a/server/session/item_lock.go
+++ b/server/session/item_lock.go
@@ -1,0 +1,76 @@
+package session
+
+import (
+	"fmt"
+
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+)
+
+func isPlayerInventoryContainer(id int32) bool {
+	switch id {
+	case protocol.ContainerHotBar, protocol.ContainerInventory, protocol.ContainerCombinedHotBarAndInventory,
+		protocol.ContainerOffhand, protocol.ContainerArmor, protocol.ContainerCursor:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Session) sameInventorySlot(a, b protocol.StackRequestSlotInfo, tx *world.Tx) bool {
+	invA, okA := s.invByID(int32(a.Container.ContainerID), tx)
+	invB, okB := s.invByID(int32(b.Container.ContainerID), tx)
+	if !okA || !okB || invA != invB {
+		return false
+	}
+	if invA == s.offHand {
+		return true
+	}
+	return a.Slot == b.Slot
+}
+
+func ensureUnlockedForInventoryMove(stack item.Stack, from, to protocol.StackRequestSlotInfo, s *Session, tx *world.Tx) error {
+	if stack.Empty() || !isPlayerInventoryContainer(int32(from.Container.ContainerID)) {
+		return nil
+	}
+	switch stack.LockMode() {
+	case item.LockInInventory:
+		if !isPlayerInventoryContainer(int32(to.Container.ContainerID)) {
+			return fmt.Errorf("item is locked in inventory")
+		}
+	case item.LockInSlot:
+		if !s.sameInventorySlot(from, to, tx) {
+			return fmt.Errorf("item is locked in slot")
+		}
+	}
+	return nil
+}
+
+func ensureUnlockedForInventoryRemoval(stack item.Stack, from protocol.StackRequestSlotInfo) error {
+	if stack.Empty() || !isPlayerInventoryContainer(int32(from.Container.ContainerID)) || !stack.Locked() {
+		return nil
+	}
+	switch stack.LockMode() {
+	case item.LockInInventory:
+		return fmt.Errorf("item is locked in inventory")
+	case item.LockInSlot:
+		return fmt.Errorf("item is locked in slot")
+	default:
+		return nil
+	}
+}
+
+func ensureUnlockedForCrafting(stack item.Stack) error {
+	if !stack.Locked() {
+		return nil
+	}
+	return fmt.Errorf("item is locked and cannot be used as a crafting ingredient")
+}
+
+func ensureUnlockedForAnvil(stack item.Stack) error {
+	if !stack.Locked() {
+		return nil
+	}
+	return fmt.Errorf("item is locked and cannot be renamed or combined in an anvil")
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `item_lock` attribute to item stacks and enforces it across multiple inventory/crafting/anvil flows, which can affect core gameplay interactions and client/server sync if edge cases are missed.
> 
> **Overview**
> Adds Bedrock `item_lock` support end-to-end: introduces `item.LockMode` stored on `item.Stack`, includes it in stack copying/comparison/stringification, and reads/writes the lock state to NBT (handling both modern `minecraft:item_lock` and legacy encodings).
> 
> Enforces lock semantics in gameplay and UI flows by blocking locked items from being moved/removed between containers, dropped/destroyed, used as crafting ingredients (crafting table/auto-craft/loom/smithing/stonecutter/grindstone), or used in anvils; also prevents pick-block and armour swaps from bypassing `LockInSlot`/`LockInInventory` restrictions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c7f7662e8892c587000c8c6df7b7cecf55d85e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added item lock feature supporting two lock modes: items can be locked to prevent removal from inventory or locked to specific slots to prevent any movement
* Locked items cannot be moved between containers, dropped, consumed in crafting recipes, or used at crafting stations (crafting table, stonecutter, loom, smithing table, grindstone) and anvils
* Slot-locked items cannot be swapped or equipped as armor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->