### PR TITLE
[codex] Add per-registry custom block states

### DIFF
--- a/server/world/block_registry.go
+++ b/server/world/block_registry.go
@@ -7,99 +7,12 @@ import (
 	"math/bits"
 	"slices"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/brentp/intintmap"
 	"github.com/df-mc/dragonfly/server/world/chunk"
-	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/segmentio/fasthash/fnv1"
-	"github.com/zaataylor/cartesian/cartesian"
 )
-
-func splitNamespace(identifier string) (ns, name string) {
-	parts := strings.Split(identifier, ":")
-	return parts[0], parts[len(parts)-1]
-}
-
-var traitLookup = map[string][]any{
-	"minecraft:facing_direction": {
-		"north", "east", "south", "west", "down", "up",
-	},
-	"minecraft:cardinal_direction": {
-		"north", "east", "south", "west",
-	},
-	"minecraft:vertical_half": {
-		"top", "bottom",
-	},
-	"minecraft:block_face": {
-		"north", "east", "south", "west", "down", "up",
-	},
-}
-
-// AddCustomBlocks registers each non-vanilla block entry's permutations as block states on the
-// DefaultBlockRegistry so they can be resolved during chunk encoding/decoding.
-func AddCustomBlocks(entries []protocol.BlockEntry) error {
-	for _, entry := range entries {
-		ns, _ := splitNamespace(entry.Name)
-		if ns == "minecraft" {
-			continue
-		}
-
-		var propertyNames []string
-		var propertyValues []any
-
-		props, ok := entry.Properties["properties"].([]any)
-		if ok {
-			for _, v := range props {
-				v := v.(map[string]any)
-				name := v["name"].(string)
-				enum := v["enum"]
-				propertyNames = append(propertyNames, name)
-				propertyValues = append(propertyValues, enum)
-			}
-		}
-
-		traits, ok := entry.Properties["traits"].([]any)
-		if ok {
-			for _, trait := range traits {
-				trait := trait.(map[string]any)
-				enabledStates := trait["enabled_states"].(map[string]any)
-				for k, enabled := range enabledStates {
-					if !strings.ContainsRune(k, ':') {
-						k = "minecraft:" + k
-					}
-					if enabled.(uint8) == 0 {
-						continue
-					}
-					v, ok := traitLookup[k]
-					if !ok {
-						return fmt.Errorf("unresolved trait %s", k)
-					}
-
-					propertyNames = append(propertyNames, k)
-					propertyValues = append(propertyValues, v)
-				}
-			}
-		}
-
-		permutations := cartesian.NewCartesianProduct(propertyValues).Values()
-
-		for _, values := range permutations {
-			m := make(map[string]any)
-			for i, value := range values {
-				name := propertyNames[i]
-				m[name] = value
-			}
-			DefaultBlockRegistry.RegisterBlockState(BlockState{
-				Name:       entry.Name,
-				Properties: m,
-			})
-		}
-	}
-
-	return nil
-}
 
 // DefaultBlockRegistry is the default (vanilla) block registry used by Dragonfly when no custom registry is provided.
 //
@@ -317,18 +230,63 @@ func (br *BasicBlockRegistry) Clone() *BasicBlockRegistry {
 	br2.blockInfos = append([]blockInfo(nil), br.blockInfos...)
 
 	if br.finalized {
-		br2.hashes = intintmap.New(len(br.blocks), 0.999)
-		for rid, b := range br2.blocks {
-			if _, hash := b.Hash(); hash == math.MaxUint64 {
-				continue
-			}
-			br2.hashes.Put(int64(br2.BlockHash(b)), int64(rid))
-		}
+		br2.rebuildBlockHashesLocked()
 		br2.networkhashToRids = make(map[uint32]uint32, len(br.networkhashToRids))
 		maps.Copy(br2.networkhashToRids, br.networkhashToRids)
 	}
 
 	return br2
+}
+
+func (br *BasicBlockRegistry) addCustomBlockState(s BlockState, scratch []byte) ([]byte, error) {
+	br.mu.Lock()
+	defer br.mu.Unlock()
+
+	h := stateHash{name: s.Name, properties: hashProperties(s.Properties)}
+	if _, ok := br.stateRuntimeIDs[h]; ok {
+		return scratch, nil
+	}
+	if _, ok := br.blockProperties[s.Name]; !ok {
+		br.blockProperties[s.Name] = s.Properties
+	}
+
+	rid := uint32(len(br.blocks))
+	br.blocks = append(br.blocks, unknownBlock{BlockState: s})
+	br.stateRuntimeIDs[h] = rid
+	if !br.finalized {
+		return scratch, nil
+	}
+
+	if bits.Len64(uint64(len(br.blocks))) != br.bitSize {
+		br.bitSize = bits.Len64(uint64(len(br.blocks)))
+		br.rebuildBlockHashesLocked()
+	}
+	br.blockInfos = append(br.blockInfos, defaultUnknownBlockInfo())
+
+	var netHash uint32
+	netHash, scratch = networkBlockHash(s.Name, s.Properties, scratch)
+	if other, ok := br.networkhashToRids[netHash]; ok {
+		otherName, otherProperties := br.blocks[other].EncodeBlock()
+		return scratch, fmt.Errorf("network block hash collision for (%s %+v) and (%s %+v)", s.Name, s.Properties, otherName, otherProperties)
+	}
+	br.networkhashToRids[netHash] = rid
+	return scratch, nil
+}
+
+func (br *BasicBlockRegistry) rebuildBlockHashesLocked() {
+	br.hashes = intintmap.New(len(br.blocks), 0.999)
+	for rid, b := range br.blocks {
+		if _, hash := b.Hash(); hash == math.MaxUint64 {
+			continue
+		}
+		br.hashes.Put(int64(br.BlockHash(b)), int64(rid))
+	}
+}
+
+func defaultUnknownBlockInfo() blockInfo {
+	var info blockInfo
+	info.setLightFilter(15)
+	return info
 }
 
 // NewBlockRegistry returns a mutable registry seeded with all vanilla block states and block implementations.
@@ -448,9 +406,8 @@ func (br *BasicBlockRegistry) Finalize() {
 		}
 		br.stateRuntimeIDs[h] = rid
 
-		var info blockInfo
+		info := defaultUnknownBlockInfo()
 		// Default to fully opaque. Blocks that implement lightDiffuser may override this (e.g., air -> 0, leaves -> 1-14).
-		info.setLightFilter(15)
 		if diffuser, ok := b.(lightDiffuser); ok {
 			info.setLightFilter(diffuser.LightDiffusionLevel())
 		}

--- a/server/world/custom_block_registry.go
+++ b/server/world/custom_block_registry.go
@@ -1,0 +1,151 @@
+package world
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/zaataylor/cartesian/cartesian"
+)
+
+var traitLookup = map[string][]any{
+	"minecraft:facing_direction": {
+		"north", "east", "south", "west", "down", "up",
+	},
+	"minecraft:cardinal_direction": {
+		"north", "east", "south", "west",
+	},
+	"minecraft:vertical_half": {
+		"top", "bottom",
+	},
+	"minecraft:block_face": {
+		"north", "east", "south", "west", "down", "up",
+	},
+	"minecraft:corner_and_cardinal_direction": {
+		"none", "inner_left", "inner_right", "outer_left", "outer_right",
+	},
+}
+
+// NewCustomBlockRegistry returns an independent registry with default block runtime IDs preserved and custom block
+// states appended after the default registry.
+func NewCustomBlockRegistry(entries []protocol.BlockEntry) (BlockRegistry, error) {
+	DefaultBlockRegistry.Finalize()
+	registry := DefaultBlockRegistry.Clone()
+	if err := registry.AddCustomBlocks(entries); err != nil {
+		return nil, err
+	}
+	return registry, nil
+}
+
+// AddCustomBlocks registers each non-vanilla block entry's permutations as block states on reg.
+func AddCustomBlocks(reg BlockRegistry, entries []protocol.BlockEntry) error {
+	basicRegistry, _ := reg.(*BasicBlockRegistry)
+	scratch := make([]byte, 0, 0xff)
+	for _, entry := range entries {
+		if namespace, _, _ := strings.Cut(entry.Name, ":"); namespace == "minecraft" {
+			continue
+		}
+
+		propertyNames, propertyValues, err := customBlockPropertySpace(entry)
+		if err != nil {
+			return err
+		}
+
+		permutations := [][]any{nil}
+		if len(propertyValues) > 0 {
+			permutations = cartesian.NewCartesianProduct(propertyValues).Values()
+		}
+
+		for _, values := range permutations {
+			properties := make(map[string]any, len(values))
+			for i, value := range values {
+				properties[propertyNames[i]] = value
+			}
+			state := BlockState{Name: entry.Name, Properties: properties}
+			if basicRegistry != nil {
+				var err error
+				scratch, err = basicRegistry.addCustomBlockState(state, scratch)
+				if err != nil {
+					return err
+				}
+				continue
+			}
+			reg.RegisterBlockState(state)
+		}
+	}
+	return nil
+}
+
+// AddCustomBlocks registers each non-vanilla block entry's permutations as block states on br.
+func (br *BasicBlockRegistry) AddCustomBlocks(entries []protocol.BlockEntry) error {
+	return AddCustomBlocks(br, entries)
+}
+
+func customBlockPropertySpace(entry protocol.BlockEntry) ([]string, []any, error) {
+	var propertyNames []string
+	var propertyValues []any
+
+	props, ok := entry.Properties["properties"].([]any)
+	if ok {
+		for i, rawV := range props {
+			v, ok := rawV.(map[string]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("expected property at index %d to be map[string]any, got %T", i, rawV)
+			}
+			name, ok := v["name"].(string)
+			if !ok {
+				return nil, nil, fmt.Errorf("expected property name to be string, got %T", v["name"])
+			}
+			enum, ok := v["enum"]
+			if !ok {
+				return nil, nil, fmt.Errorf("expected property %s enum to be present", name)
+			}
+			propertyNames = append(propertyNames, name)
+			propertyValues = append(propertyValues, enum)
+		}
+	}
+
+	traits, ok := entry.Properties["traits"].([]any)
+	if ok {
+		for i, rawTrait := range traits {
+			trait, ok := rawTrait.(map[string]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("expected trait at index %d to be map[string]any, got %T", i, rawTrait)
+			}
+			enabledStates, ok := trait["enabled_states"].(map[string]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("expected enabled_states to be map[string]any, got %T", trait["enabled_states"])
+			}
+			for k, rawEnabled := range enabledStates {
+				if !strings.ContainsRune(k, ':') {
+					k = "minecraft:" + k
+				}
+				if !customBlockTraitEnabled(rawEnabled) {
+					continue
+				}
+				v, ok := traitLookup[k]
+				if !ok {
+					return nil, nil, fmt.Errorf("unresolved trait %s", k)
+				}
+
+				propertyNames = append(propertyNames, k)
+				propertyValues = append(propertyValues, v)
+			}
+		}
+	}
+
+	return propertyNames, propertyValues, nil
+}
+
+func customBlockTraitEnabled(v any) bool {
+	switch v := v.(type) {
+	case bool:
+		return v
+	case uint8:
+		return v != 0
+	case int32:
+		return v != 0
+	default:
+		return false
+	}
+}

--- a/server/world/custom_block_registry_test.go
+++ b/server/world/custom_block_registry_test.go
@@ -1,0 +1,79 @@
+package world
+
+import (
+	"testing"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+)
+
+func TestAddCustomBlocksPreservesVanillaRuntimeIDs(t *testing.T) {
+	DefaultBlockRegistry.Finalize()
+	registry := DefaultBlockRegistry.Clone()
+	baseCount := registry.BlockCount()
+	airRID := registry.AirRuntimeID()
+
+	err := registry.AddCustomBlocks([]protocol.BlockEntry{{
+		Name: "dragonfly:test_block",
+		Properties: map[string]any{
+			"properties": []any{
+				map[string]any{
+					"name": "dragonfly:variant",
+					"enum": []any{int32(0), int32(1)},
+				},
+			},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("AddCustomBlocks() error = %v", err)
+	}
+
+	if got := registry.AirRuntimeID(); got != airRID {
+		t.Fatalf("expected air runtime ID %d to be preserved, got %d", airRID, got)
+	}
+	rid, ok := registry.StateToRuntimeID("dragonfly:test_block", map[string]any{"dragonfly:variant": int32(0)})
+	if !ok {
+		t.Fatal("expected custom block runtime ID")
+	}
+	if rid != uint32(baseCount) {
+		t.Fatalf("expected first custom runtime ID %d, got %d", baseCount, rid)
+	}
+	if got := registry.BlockCount(); got != baseCount+2 {
+		t.Fatalf("expected block count %d, got %d", baseCount+2, got)
+	}
+}
+
+func TestAddCustomBlocksSkipsDuplicateStates(t *testing.T) {
+	DefaultBlockRegistry.Finalize()
+	registry := DefaultBlockRegistry.Clone()
+
+	entries := []protocol.BlockEntry{{
+		Name:       "dragonfly:plain_block",
+		Properties: map[string]any{},
+	}}
+	if err := registry.AddCustomBlocks(entries); err != nil {
+		t.Fatalf("AddCustomBlocks() first error = %v", err)
+	}
+	count := registry.BlockCount()
+	if err := registry.AddCustomBlocks(entries); err != nil {
+		t.Fatalf("AddCustomBlocks() second error = %v", err)
+	}
+	if got := registry.BlockCount(); got != count {
+		t.Fatalf("expected duplicate state to be skipped, count %d -> %d", count, got)
+	}
+}
+
+func TestNewCustomBlockRegistryPreservesVanillaRuntimeIDs(t *testing.T) {
+	DefaultBlockRegistry.Finalize()
+	airRID := DefaultBlockRegistry.AirRuntimeID()
+
+	registry, err := NewCustomBlockRegistry([]protocol.BlockEntry{{
+		Name:       "dragonfly:plain_block",
+		Properties: map[string]any{},
+	}})
+	if err != nil {
+		t.Fatalf("NewCustomBlockRegistry() error = %v", err)
+	}
+	if got := registry.AirRuntimeID(); got != airRID {
+		t.Fatalf("expected air runtime ID %d to be preserved, got %d", airRID, got)
+	}
+}


### PR DESCRIPTION
## What changed

- Added a registry-scoped custom block registration path.
- Added `NewCustomBlockRegistry` for callers that need a per-server registry with default runtime IDs preserved.
- Kept normal `RegisterBlockState` strict while allowing duplicate StartGame custom states to be skipped only on the custom-block helper path.
- Added tests for vanilla runtime ID preservation and duplicate custom state handling.

## Why

Lunar needs to handle custom block palettes for multiple upstream servers in one process. Mutating `DefaultBlockRegistry` conflicts across sessions, and registering states on a mutable clone then finalizing can shift vanilla runtime IDs.

## Validation

- `go test ./server/world`
