### PR TITLE
[Cursor Review] Implement piercing enchantment

### DIFF
--- a/server/entity/projectile.go
+++ b/server/entity/projectile.go
@@ -1,6 +1,12 @@
 package entity
 
 import (
+	"iter"
+	"math"
+	"math/rand/v2"
+	"slices"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/cube/trace"
@@ -9,10 +15,6 @@ import (
 	"github.com/df-mc/dragonfly/server/item/potion"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"iter"
-	"math"
-	"math/rand/v2"
-	"time"
 )
 
 // ProjectileBehaviourConfig allows the configuration of projectiles. Calling
@@ -80,6 +82,9 @@ type ProjectileBehaviourConfig struct {
 	// CollisionPosition specifies the position that the projectile is stuck
 	// in. If non-empty, the entity will not move.
 	CollisionPosition cube.Pos
+	// PiercingLevel specifies how many entities the projectile can pierce
+	// through without breaking.
+	PiercingLevel int
 }
 
 func (conf ProjectileBehaviourConfig) Apply(data *world.EntityData) {
@@ -109,6 +114,8 @@ type ProjectileBehaviour struct {
 
 	collisionPos cube.Pos
 	collided     bool
+
+	collidedEntities []*world.EntityHandle
 }
 
 // Owner returns the owner of the projectile.
@@ -170,6 +177,7 @@ func (lt *ProjectileBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 	case trace.EntityResult:
 		if l, ok := r.Entity().(Living); ok && lt.conf.Damage >= 0 {
 			lt.hitEntity(l, e, vel)
+			lt.collidedEntities = append(lt.collidedEntities, l.H())
 		}
 	case trace.BlockResult:
 		bpos := r.BlockPosition()
@@ -185,7 +193,9 @@ func (lt *ProjectileBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 		lt.conf.Hit(e, tx, result)
 	}
 
-	lt.close = true
+	if len(lt.collidedEntities) > lt.conf.PiercingLevel {
+		lt.close = true
+	}
 	return m
 }
 
@@ -313,7 +323,9 @@ func (lt *ProjectileBehaviour) tickMovement(e *Ent, tx *world.Tx) (*Movement, tr
 
 				vel = mgl64.Vec3{x * mx, y * my, z * mz}
 			} else {
-				vel = zeroVec3
+				if lt.conf.PiercingLevel == 0 {
+					vel = zeroVec3
+				}
 			}
 			end = hit.Position()
 		}
@@ -322,15 +334,19 @@ func (lt *ProjectileBehaviour) tickMovement(e *Ent, tx *world.Tx) (*Movement, tr
 }
 
 // ignores returns a function to ignore entities in trace.Perform that are
-// either a spectator, not living, the entity itself or its owner in the first
-// 5 ticks.
+// either a spectator, not living, the entity itself, its owner in the first
+// 5 ticks, or an entity it already collided with.
 func (lt *ProjectileBehaviour) ignores(e *Ent) trace.EntityFilter {
 	return func(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
 		return func(yield func(world.Entity) bool) {
 			for other := range seq {
 				g, ok := other.(interface{ GameMode() world.GameMode })
+				spectator := ok && !g.GameMode().HasCollision()
+				itself := e.H() == other.H()
 				_, living := other.(Living)
-				if (ok && !g.GameMode().HasCollision()) || e.H() == other.H() || !living || (e.data.Age < time.Second/4 && lt.conf.Owner == other.H()) {
+				owner := e.data.Age < time.Second/4 && lt.conf.Owner == other.H()
+				collidedEntity := slices.Contains(lt.collidedEntities, other.H())
+				if spectator || itself || !living || owner || collidedEntity {
 					continue
 				}
 				if !yield(other) {

--- a/server/entity/projectile.go
+++ b/server/entity/projectile.go
@@ -322,10 +322,8 @@ func (lt *ProjectileBehaviour) tickMovement(e *Ent, tx *world.Tx) (*Movement, tr
 				mx, my, mz := hit.Face().Axis().Vec3().Mul(-2).Add(mgl64.Vec3{1, 1, 1}).Elem()
 
 				vel = mgl64.Vec3{x * mx, y * my, z * mz}
-			} else {
-				if lt.conf.PiercingLevel == 0 {
-					vel = zeroVec3
-				}
+			} else if lt.conf.PiercingLevel == 0 {
+				vel = zeroVec3
 			}
 			end = hit.Position()
 		}

--- a/server/entity/register.go
+++ b/server/entity/register.go
@@ -47,7 +47,11 @@ var conf = world.EntityRegistryConfig{
 	SplashPotion: func(opts world.EntitySpawnOpts, t any, owner world.Entity) *world.EntityHandle {
 		return NewSplashPotion(opts, t.(potion.Potion), owner)
 	},
-	Arrow: func(opts world.EntitySpawnOpts, damage float64, owner world.Entity, critical, disallowPickup, obtainArrowOnPickup bool, punchLevel int, tip any) *world.EntityHandle {
+	Arrow: func(
+		opts world.EntitySpawnOpts, damage float64, owner world.Entity,
+		critical, disallowPickup, obtainArrowOnPickup bool,
+		punchLevel int, pierceLevel int, tip any,
+	) *world.EntityHandle {
 		conf := arrowConf
 		conf.Damage, conf.Potion, conf.Owner = damage, tip.(potion.Potion), owner.H()
 		conf.KnockBackForceAddend = float64(punchLevel) * enchantment.Punch.KnockBackMultiplier()
@@ -56,6 +60,7 @@ var conf = world.EntityRegistryConfig{
 			conf.PickupItem = item.NewStack(item.Arrow{Tip: tip.(potion.Potion)}, 1)
 		}
 		conf.Critical = critical
+		conf.PiercingLevel = pierceLevel
 		return opts.New(ArrowType, conf)
 	},
 }

--- a/server/item/bow.go
+++ b/server/item/bow.go
@@ -79,7 +79,7 @@ func (Bow) Release(releaser Releaser, tx *world.Tx, ctx *UseContext, duration ti
 
 	create := tx.World().EntityRegistry().Config().Arrow
 	opts := world.EntitySpawnOpts{Position: eyePosition(releaser), Velocity: releaser.Rotation().Vec3().Mul(force * 5), Rotation: releaser.Rotation().Neg()}
-	projectile := tx.AddEntity(create(opts, damage, releaser, force >= 1, false, !creative && consume, punchLevel, tip))
+	projectile := tx.AddEntity(create(opts, damage, releaser, force >= 1, false, !creative && consume, punchLevel, 0, tip))
 	if f, ok := projectile.(interface{ SetOnFire(duration time.Duration) }); ok {
 		f.SetOnFire(burnDuration)
 	}

--- a/server/item/crossbow.go
+++ b/server/item/crossbow.go
@@ -122,18 +122,21 @@ func (c Crossbow) ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext
 	held, _ := releaser.HeldItems()
 	creative := releaser.GameMode().CreativeInventory()
 
-	multishot := false
+	pierceLevel, multishot := 0, false
 	for _, enchant := range held.Enchantments() {
 		if _, ok := enchant.Type().(interface{ MultipleProjectiles() bool }); ok {
 			multishot = true
 			break
 		}
+		if _, ok := enchant.Type().(interface{ Pierces() bool }); ok {
+			pierceLevel = enchant.Level()
+		}
 	}
 
-	c.shoot(releaser, tx, 0, !creative)
+	c.shoot(releaser, tx, 0, !creative, pierceLevel)
 	if multishot {
-		c.shoot(releaser, tx, -10, false)
-		c.shoot(releaser, tx, 10, false)
+		c.shoot(releaser, tx, -10, false, 0)
+		c.shoot(releaser, tx, 10, false, 0)
 	}
 	c.applyDamage(ctx)
 
@@ -146,7 +149,7 @@ func (c Crossbow) ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext
 }
 
 // shoot fires the crossbow's loaded projectiles.
-func (c Crossbow) shoot(releaser Releaser, tx *world.Tx, offsetAngle float64, canObtainPickup bool) {
+func (c Crossbow) shoot(releaser Releaser, tx *world.Tx, offsetAngle float64, canObtainPickup bool, pierceLevel int) {
 	rot := releaser.Rotation()
 	dirVec := cube.Rotation{rot[0] + offsetAngle, rot[1]}.Vec3()
 
@@ -164,7 +167,7 @@ func (c Crossbow) shoot(releaser Releaser, tx *world.Tx, offsetAngle float64, ca
 			Position: torsoPosition(releaser),
 			Velocity: dirVec.Mul(5.15),
 			Rotation: rot.Neg(),
-		}, 9, releaser, false, false, canObtainPickup, 0, c.Item.Item().(Arrow).Tip)
+		}, 9, releaser, false, false, canObtainPickup, 0, pierceLevel, c.Item.Item().(Arrow).Tip)
 		tx.AddEntity(arrow)
 	}
 }

--- a/server/item/enchantment/piercing.go
+++ b/server/item/enchantment/piercing.go
@@ -1,0 +1,40 @@
+package enchantment
+
+import (
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+// Piercing is an enchantment that allows arrows to damage and pierce through multiple entities, including shields.
+var Piercing piercing
+
+type piercing struct{}
+
+func (p piercing) Name() string {
+	return "Piercing"
+}
+
+func (p piercing) MaxLevel() int {
+	return 4
+}
+
+func (p piercing) Cost(level int) (int, int) {
+	return 1 + (level-1)*10, 50
+}
+
+func (p piercing) Rarity() item.EnchantmentRarity {
+	return item.EnchantmentRarityCommon
+}
+
+func (p piercing) CompatibleWithEnchantment(t item.EnchantmentType) bool {
+	return t != Multishot
+}
+
+func (p piercing) CompatibleWithItem(i world.Item) bool {
+	_, ok := i.(item.Crossbow)
+	return ok
+}
+
+func (p piercing) Pierces() bool {
+	return true
+}

--- a/server/item/enchantment/register.go
+++ b/server/item/enchantment/register.go
@@ -37,7 +37,7 @@ func init() {
 	// TODO: (31) Loyalty.
 	// TODO: (32) Channeling.
 	item.RegisterEnchantment(33, Multishot)
-	// TODO: (34) Piercing.
+	item.RegisterEnchantment(34, Piercing)
 	item.RegisterEnchantment(35, QuickCharge)
 	item.RegisterEnchantment(36, SoulSpeed)
 	item.RegisterEnchantment(37, SwiftSneak)

--- a/server/world/entity.go
+++ b/server/world/entity.go
@@ -366,14 +366,21 @@ type EntityRegistryConfig struct {
 	FallingBlock       func(opts EntitySpawnOpts, bl Block) *EntityHandle
 	TNT                func(opts EntitySpawnOpts, fuse time.Duration) *EntityHandle
 	BottleOfEnchanting func(opts EntitySpawnOpts, owner Entity) *EntityHandle
-	Arrow              func(opts EntitySpawnOpts, damage float64, owner Entity, critical, disallowPickup, obtainArrowOnPickup bool, punchLevel int, tip any) *EntityHandle
 	Egg                func(opts EntitySpawnOpts, owner Entity) *EntityHandle
 	EnderPearl         func(opts EntitySpawnOpts, owner Entity) *EntityHandle
-	Firework           func(opts EntitySpawnOpts, firework Item, owner Entity, sidewaysVelocityMultiplier, upwardsAcceleration float64, attached bool) *EntityHandle
 	LingeringPotion    func(opts EntitySpawnOpts, t any, owner Entity) *EntityHandle
 	Snowball           func(opts EntitySpawnOpts, owner Entity) *EntityHandle
 	SplashPotion       func(opts EntitySpawnOpts, t any, owner Entity) *EntityHandle
 	Lightning          func(opts EntitySpawnOpts) *EntityHandle
+
+	Arrow func(
+		opts EntitySpawnOpts, damage float64, owner Entity, critical,
+		disallowPickup, obtainArrowOnPickup bool, punchLevel int, pierceLevel int, tip any,
+	) *EntityHandle
+
+	Firework func(
+		opts EntitySpawnOpts, firework Item, owner Entity, sidewaysVelocityMultiplier, upwardsAcceleration float64, attached bool,
+	) *EntityHandle
 }
 
 // New creates an EntityRegistry using conf and the EntityTypes passed.


### PR DESCRIPTION
Cursor review mirror of df-mc/dragonfly#1246

Original: https://github.com/df-mc/dragonfly/pull/1246

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core projectile collision/trace behaviour to allow arrows to pass through multiple entities, which could affect combat balance and collision edge-cases. Also alters the `EntityRegistryConfig.Arrow` function signature, requiring downstream callers to be updated.
> 
> **Overview**
> Adds a new `Piercing` enchantment (registered as id `34`) for crossbows, marked incompatible with `Multishot`, and wires crossbow firing to pass the enchantment level into spawned arrows.
> 
> Extends projectile behaviour with `PiercingLevel` and tracks already-hit entities so a projectile can continue travelling through entities until it exceeds its pierce limit, while preventing repeat hits on the same entity.
> 
> Updates the `EntityRegistryConfig.Arrow` factory signature (and default registry implementation/call sites) to accept `pierceLevel`; bow-spawned arrows pass `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ac7297b1bc655478f3e18405bcf376ae5eb8f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Piercing enchantment for crossbows (max level 4). Arrows can now pierce through multiple entities instead of stopping on the first impact, with the number of entities penetrated determined by the enchantment level.
  * Piercing enchantment is incompatible with Multishot.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HashimTheArab/dragonfly/pull/26)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->