### PR TITLE
[Cursor Review] feat(world/view_layer.go): implement block view layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /world/
 /players/
 /resources/
+
+# AI
+.omx

--- a/server/block/beetroot_seeds.go
+++ b/server/block/beetroot_seeds.go
@@ -21,16 +21,16 @@ func (BeetrootSeeds) SameCrop(c Crop) bool {
 }
 
 // BoneMeal ...
-func (b BeetrootSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (b BeetrootSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if b.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	if rand.Float64() < 0.75 {
 		b.Growth++
 		tx.SetBlock(pos, b, nil)
-		return true
+		return item.BoneMealResultSmall
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // UseOnBlock ...

--- a/server/block/carrot.go
+++ b/server/block/carrot.go
@@ -38,13 +38,13 @@ func (c Carrot) Consume(_ *world.Tx, co item.Consumer) item.Stack {
 }
 
 // BoneMeal ...
-func (c Carrot) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (c Carrot) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if c.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	c.Growth = min(c.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, c, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/cocoa_bean.go
+++ b/server/block/cocoa_bean.go
@@ -1,12 +1,13 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/model"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // CocoaBean is a crop block found in jungle biomes.
@@ -20,13 +21,13 @@ type CocoaBean struct {
 }
 
 // BoneMeal ...
-func (c CocoaBean) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (c CocoaBean) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if c.Age == 2 {
-		return false
+		return item.BoneMealResultNone
 	}
 	c.Age++
 	tx.SetBlock(pos, c, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // HasLiquidDrops ...

--- a/server/block/cube/trace/bbox.go
+++ b/server/block/cube/trace/bbox.go
@@ -99,6 +99,41 @@ func BBoxIntercept(bb cube.BBox, start, end mgl64.Vec3) (result BBoxResult, ok b
 	return BBoxResult{bb: bb, pos: *vec, face: f}, true
 }
 
+// BBoxIntersects checks if the line segment from start to end intersects the BBox.
+// Unlike BBoxIntercept, it only reports whether an intersection exists and does not
+// calculate the closest hit position or face.
+func BBoxIntersects(bb cube.BBox, start, end mgl64.Vec3) bool {
+	min, max := bb.Min(), bb.Max()
+	dir := end.Sub(start)
+	tMin, tMax := 0.0, 1.0
+
+	for axis := range 3 {
+		if mgl64.FloatEqual(dir[axis], 0) {
+			if start[axis] < min[axis] || start[axis] > max[axis] {
+				return false
+			}
+			continue
+		}
+
+		inv := 1 / dir[axis]
+		t1 := (min[axis] - start[axis]) * inv
+		t2 := (max[axis] - start[axis]) * inv
+		if t1 > t2 {
+			t1, t2 = t2, t1
+		}
+		if t1 > tMin {
+			tMin = t1
+		}
+		if t2 < tMax {
+			tMax = t2
+		}
+		if tMin > tMax {
+			return false
+		}
+	}
+	return true
+}
+
 // vec3OnLineWithX returns an mgl64.Vec3 on the line between mgl64.Vec3 a and b with an X value passed. If no such vec3
 // could be found, the bool returned is false.
 func vec3OnLineWithX(a, b mgl64.Vec3, x float64) *mgl64.Vec3 {

--- a/server/block/cube/trace/block.go
+++ b/server/block/cube/trace/block.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/block/model"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
 	"math"
@@ -69,4 +70,24 @@ func BlockIntercept(pos cube.Pos, src world.BlockSource, b world.Block, start, e
 	}
 
 	return BlockResult{bb: hit.BBox(), pos: hit.Position(), face: hit.Face(), blockPos: pos}, true
+}
+
+// BlockIntersects checks if the line segment from start to end intersects the block model of b at pos. Unlike
+// BlockIntercept, it only reports whether an intersection exists and does not calculate the closest hit position, face,
+// or bounding box.
+func BlockIntersects(pos cube.Pos, src world.BlockSource, b world.Block, start, end mgl64.Vec3) bool {
+	m := b.Model()
+	switch m.(type) {
+	case model.Empty:
+		return false
+	case model.Solid:
+		return BBoxIntersects(cube.Box(0, 0, 0, 1, 1, 1).Translate(pos.Vec3()), start, end)
+	}
+
+	for _, bb := range m.BBox(pos, src) {
+		if BBoxIntersects(bb.Translate(pos.Vec3()), start, end) {
+			return true
+		}
+	}
+	return false
 }

--- a/server/block/double_flower.go
+++ b/server/block/double_flower.go
@@ -24,9 +24,9 @@ func (d DoubleFlower) FlammabilityInfo() FlammabilityInfo {
 }
 
 // BoneMeal ...
-func (d DoubleFlower) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (d DoubleFlower) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	dropItem(tx, item.NewStack(d, 1), pos.Vec3Centre())
-	return true
+	return item.BoneMealResultSmall
 }
 
 // NeighbourUpdateTick ...

--- a/server/block/fern.go
+++ b/server/block/fern.go
@@ -25,14 +25,14 @@ func (g Fern) BreakInfo() BreakInfo {
 }
 
 // BoneMeal attempts to affect the block using a bone meal item.
-func (g Fern) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (g Fern) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	upper := DoubleTallGrass{Type: FernDoubleTallGrass(), UpperPart: true}
 	if replaceableWith(tx, pos.Side(cube.FaceUp), upper) {
 		tx.SetBlock(pos, DoubleTallGrass{Type: FernDoubleTallGrass()}, nil)
 		tx.SetBlock(pos.Side(cube.FaceUp), upper, nil)
-		return true
+		return item.BoneMealResultSmall
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // CompostChance ...

--- a/server/block/flower.go
+++ b/server/block/flower.go
@@ -1,13 +1,14 @@
 package block
 
 import (
+	"math/rand/v2"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/entity/effect"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
-	"time"
 )
 
 // Flower is a non-solid plant that occur in a variety of shapes and colours. They are primarily used for decoration
@@ -32,7 +33,8 @@ func (f Flower) EntityInside(_ cube.Pos, _ *world.Tx, e world.Entity) {
 }
 
 // BoneMeal ...
-func (f Flower) BoneMeal(pos cube.Pos, tx *world.Tx) (success bool) {
+func (f Flower) BoneMeal(pos cube.Pos, tx *world.Tx) (result item.BoneMealResult) {
+	result = item.BoneMealResultNone
 	if f.Type == WitherRose() {
 		return
 	}
@@ -54,7 +56,7 @@ func (f Flower) BoneMeal(pos cube.Pos, tx *world.Tx) (success bool) {
 			}
 		}
 		tx.SetBlock(p, Flower{Type: flowerType}, nil)
-		success = true
+		result = item.BoneMealResultArea
 	}
 	return
 }

--- a/server/block/grass.go
+++ b/server/block/grass.go
@@ -1,9 +1,10 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/world"
-	"math/rand/v2"
 )
 
 // Grass blocks generate abundantly across the surface of the world.
@@ -89,7 +90,7 @@ func (g Grass) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
 		}
 	}
 
-	return false
+	return true
 }
 
 // BreakInfo ...

--- a/server/block/grass.go
+++ b/server/block/grass.go
@@ -4,6 +4,7 @@ import (
 	"math/rand/v2"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 )
 
@@ -79,18 +80,19 @@ func (g Grass) RandomTick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 }
 
 // BoneMeal ...
-func (g Grass) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
-	for i := 0; i < 14; i++ {
+func (g Grass) BoneMeal(pos cube.Pos, tx *world.Tx) (result item.BoneMealResult) {
+	result = item.BoneMealResultNone
+	for range 14 {
 		c := pos.Add(cube.Pos{rand.IntN(6) - 3, 0, rand.IntN(6) - 3})
 		above := c.Side(cube.FaceUp)
 		_, air := tx.Block(above).(Air)
 		_, grass := tx.Block(c).(Grass)
 		if air && grass {
 			tx.SetBlock(above, plantSelection[rand.IntN(len(plantSelection))], nil)
+			result = item.BoneMealResultArea
 		}
 	}
-
-	return true
+	return
 }
 
 // BreakInfo ...

--- a/server/block/kelp.go
+++ b/server/block/kelp.go
@@ -1,11 +1,12 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // Kelp is an underwater block which can grow on top of solids underwater.
@@ -24,7 +25,7 @@ func (k Kelp) SmeltInfo() item.SmeltInfo {
 }
 
 // BoneMeal ...
-func (k Kelp) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (k Kelp) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	for y := pos.Y(); y <= tx.Range()[1]; y++ {
 		currentPos := cube.Pos{pos.X(), y, pos.Z()}
 		block := tx.Block(currentPos)
@@ -36,11 +37,11 @@ func (k Kelp) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
 		}
 		if water, ok := block.(Water); ok && water.Depth == 8 {
 			tx.SetBlock(currentPos, Kelp{Age: k.Age + 1}, nil)
-			return true
+			return item.BoneMealResultSmall
 		}
 		break
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // BreakInfo ...

--- a/server/block/melon_seeds.go
+++ b/server/block/melon_seeds.go
@@ -1,11 +1,12 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // MelonSeeds grow melon blocks.
@@ -62,13 +63,13 @@ func (m MelonSeeds) RandomTick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 }
 
 // BoneMeal ...
-func (m MelonSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (m MelonSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if m.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	m.Growth = min(m.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, m, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/pink_petals.go
+++ b/server/block/pink_petals.go
@@ -21,14 +21,14 @@ type PinkPetals struct {
 }
 
 // BoneMeal ...
-func (p PinkPetals) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (p PinkPetals) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if p.AdditionalCount < 3 {
 		p.AdditionalCount++
 		tx.SetBlock(pos, p, nil)
-		return true
+		return item.BoneMealResultSmall
 	}
 	dropItem(tx, item.NewStack(p, 1), pos.Vec3Centre())
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/potato.go
+++ b/server/block/potato.go
@@ -43,13 +43,13 @@ func (p Potato) Consume(_ *world.Tx, c item.Consumer) item.Stack {
 }
 
 // BoneMeal ...
-func (p Potato) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (p Potato) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if p.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	p.Growth = min(p.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, p, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/pumpkin_seeds.go
+++ b/server/block/pumpkin_seeds.go
@@ -1,11 +1,12 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // PumpkinSeeds grow pumpkin blocks.
@@ -62,13 +63,13 @@ func (p PumpkinSeeds) RandomTick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 }
 
 // BoneMeal ...
-func (p PumpkinSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (p PumpkinSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if p.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	p.Growth = min(p.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, p, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/sea_pickle.go
+++ b/server/block/sea_pickle.go
@@ -1,12 +1,13 @@
 package block
 
 import (
+	"math"
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math"
-	"math/rand/v2"
 )
 
 // SeaPickle is a small stationary underwater block that emits light, and is typically found in colonies of up to
@@ -41,12 +42,12 @@ func (SeaPickle) canSurvive(pos cube.Pos, tx *world.Tx) bool {
 }
 
 // BoneMeal ...
-func (s SeaPickle) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (s SeaPickle) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if s.Dead {
-		return false
+		return item.BoneMealResultNone
 	}
 	if coral, ok := tx.Block(pos.Side(cube.FaceDown)).(CoralBlock); !ok || coral.Dead {
-		return false
+		return item.BoneMealResultNone
 	}
 
 	if s.AdditionalCount != 3 {
@@ -74,7 +75,7 @@ func (s SeaPickle) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
 		}
 	}
 
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/block/short_grass.go
+++ b/server/block/short_grass.go
@@ -27,14 +27,14 @@ func (g ShortGrass) BreakInfo() BreakInfo {
 }
 
 // BoneMeal attempts to affect the block using a bone meal item.
-func (g ShortGrass) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (g ShortGrass) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	upper := DoubleTallGrass{Type: NormalDoubleTallGrass(), UpperPart: true}
 	if replaceableWith(tx, pos.Side(cube.FaceUp), upper) {
 		tx.SetBlock(pos, DoubleTallGrass{Type: NormalDoubleTallGrass()}, nil)
 		tx.SetBlock(pos.Side(cube.FaceUp), upper, nil)
-		return true
+		return item.BoneMealResultSmall
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // CompostChance ...

--- a/server/block/sugar_cane.go
+++ b/server/block/sugar_cane.go
@@ -1,11 +1,12 @@
 package block
 
 import (
+	"math/rand/v2"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand/v2"
 )
 
 // SugarCane is a plant block that generates naturally near water.
@@ -63,7 +64,7 @@ func (c SugarCane) RandomTick(pos cube.Pos, tx *world.Tx, _ *rand.Rand) {
 }
 
 // BoneMeal ...
-func (c SugarCane) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (c SugarCane) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	for _, ok := tx.Block(pos.Side(cube.FaceDown)).(SugarCane); ok; _, ok = tx.Block(pos.Side(cube.FaceDown)).(SugarCane) {
 		pos = pos.Side(cube.FaceDown)
 	}
@@ -73,9 +74,9 @@ func (c SugarCane) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
 				tx.SetBlock(pos.Add(cube.Pos{0, y}), SugarCane{}, nil)
 			}
 		}
-		return true
+		return item.BoneMealResultSmall
 	}
-	return false
+	return item.BoneMealResultNone
 }
 
 // canGrowHere implements logic to check if sugar cane can live/grow here.

--- a/server/block/wheat_seeds.go
+++ b/server/block/wheat_seeds.go
@@ -21,13 +21,13 @@ func (WheatSeeds) SameCrop(c Crop) bool {
 }
 
 // BoneMeal ...
-func (s WheatSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) bool {
+func (s WheatSeeds) BoneMeal(pos cube.Pos, tx *world.Tx) item.BoneMealResult {
 	if s.Growth == 7 {
-		return false
+		return item.BoneMealResultNone
 	}
 	s.Growth = min(s.Growth+rand.IntN(4)+2, 7)
 	tx.SetBlock(pos, s, nil)
-	return true
+	return item.BoneMealResultSmall
 }
 
 // UseOnBlock ...

--- a/server/item/bone_meal.go
+++ b/server/item/bone_meal.go
@@ -7,20 +7,40 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
+// BoneMealResult represents the outcome of a bone meal interaction with a block,
+// determining the intensity of the particle effect displayed.
+type BoneMealResult int
+
+const (
+	// BoneMealResultNone indicates that the bone meal had no effect on the block.
+	BoneMealResultNone BoneMealResult = iota
+	// BoneMealResultSmall indicates a minor growth effect, produces a small particle burst.
+	BoneMealResultSmall
+	// BoneMealResultArea indicates a significant growth effect over an area, produces a large particle burst.
+	BoneMealResultArea
+)
+
 // BoneMeal is an item used to force growth in plants & crops.
 type BoneMeal struct{}
 
 // BoneMealAffected represents a block that is affected when bone meal is used on it.
 type BoneMealAffected interface {
 	// BoneMeal attempts to affect the block using a bone meal item.
-	BoneMeal(pos cube.Pos, tx *world.Tx) bool
+	BoneMeal(pos cube.Pos, tx *world.Tx) BoneMealResult
 }
 
 // UseOnBlock ...
 func (b BoneMeal) UseOnBlock(pos cube.Pos, _ cube.Face, _ mgl64.Vec3, tx *world.Tx, _ User, ctx *UseContext) bool {
-	if bm, ok := tx.Block(pos).(BoneMealAffected); ok && bm.BoneMeal(pos, tx) {
+	if bm, ok := tx.Block(pos).(BoneMealAffected); ok {
+		result := bm.BoneMeal(pos, tx)
+		if result == BoneMealResultNone {
+			return false
+		}
+
 		ctx.SubtractFromCount(1)
-		tx.AddParticle(pos.Vec3(), particle.BoneMeal{})
+		tx.AddParticle(pos.Vec3(), particle.BoneMeal{
+			Area: result == BoneMealResultArea,
+		})
 		return true
 	}
 	return false

--- a/server/item/crossbow.go
+++ b/server/item/crossbow.go
@@ -135,6 +135,7 @@ func (c Crossbow) ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext
 	arrowConf := world.ArrowSpawnConfig{
 		Damage:              9,
 		Owner:               releaser,
+		Critical:            true,
 		ObtainArrowOnPickup: !creative,
 		PiercingLevel:       pierceLevel,
 	}

--- a/server/item/crossbow.go
+++ b/server/item/crossbow.go
@@ -155,6 +155,12 @@ func (c Crossbow) ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext
 	return true
 }
 
+// CanCharge ...
+func (c Crossbow) CanCharge(releaser Releaser, _ *world.Tx, ctx *UseContext) bool {
+	_, found := c.findProjectile(releaser, ctx)
+	return found && !c.Item.Empty()
+}
+
 // shoot fires the crossbow's loaded projectiles.
 func (c Crossbow) shoot(releaser Releaser, tx *world.Tx, offsetAngle float64, arrowConf world.ArrowSpawnConfig) {
 	rot := releaser.Rotation()

--- a/server/item/item.go
+++ b/server/item/item.go
@@ -2,12 +2,13 @@ package item
 
 import (
 	"encoding/binary"
+	"image/color"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/entity/effect"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"image/color"
-	"time"
 )
 
 // MaxCounter represents an item that has a specific max count. By default, each item will be expected to have
@@ -168,6 +169,8 @@ type Chargeable interface {
 	ContinueCharge(releaser Releaser, tx *world.Tx, ctx *UseContext, duration time.Duration)
 	// ReleaseCharge is called when an item is being released.
 	ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext) bool
+	// CanCharge returns whether the item can currently be charged.
+	CanCharge(releaser Releaser, tx *world.Tx, ctx *UseContext) bool
 }
 
 // User represents an entity that is able to use an item in the world, typically entities such as players,

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -73,7 +73,8 @@ type Handler interface {
 	// HandleBlockBreak handles a block that is being broken by a player. ctx.Cancel() may be called to cancel
 	// the block being broken. A pointer to a slice of the block's drops is passed, and may be altered to change
 	// what items will actually be dropped. If the block being broken is a private view-layer block, drops and xp
-	// start empty and modifications to them are ignored: Private breaks only remove the viewer's override.
+	// start empty and modifications to them are ignored: Private breaks only remove the viewer's override. Use
+	// ctx.Val().ViewLayer().Block(pos) to check if the block being broken is private.
 	HandleBlockBreak(ctx *Context, pos cube.Pos, drops *[]item.Stack, xp *int)
 	// HandleBlockPlace handles the player placing a specific block at a position in its world. ctx.Cancel()
 	// may be called to cancel the block being placed.

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -72,7 +72,8 @@ type Handler interface {
 	HandleStartBreak(ctx *Context, pos cube.Pos)
 	// HandleBlockBreak handles a block that is being broken by a player. ctx.Cancel() may be called to cancel
 	// the block being broken. A pointer to a slice of the block's drops is passed, and may be altered to change
-	// what items will actually be dropped.
+	// what items will actually be dropped. If the block being broken is a private view-layer block, drops and xp
+	// start empty and modifications to them are ignored: Private breaks only remove the viewer's override.
 	HandleBlockBreak(ctx *Context, pos cube.Pos, drops *[]item.Stack, xp *int)
 	// HandleBlockPlace handles the player placing a specific block at a position in its world. ctx.Cancel()
 	// may be called to cancel the block being placed.

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -67,13 +67,15 @@ type Handler interface {
 	// be called to cancel the fire being extinguished.
 	// cube.Pos can be used to see where was the fire extinguished, may be used to cancel this on specific positions.
 	HandleFireExtinguish(ctx *Context, pos cube.Pos)
-	// HandleStartBreak handles the player starting to break a block at the position passed. ctx.Cancel() may
-	// be called to stop the player from breaking the block completely.
-	HandleStartBreak(ctx *Context, pos cube.Pos)
-	// HandleBlockBreak handles a block that is being broken by a player. ctx.Cancel() may be called to cancel
-	// the block being broken. A pointer to a slice of the block's drops is passed, and may be altered
-	// to change what items will actually be dropped.
-	HandleBlockBreak(ctx *Context, pos cube.Pos, drops *[]item.Stack, xp *int)
+	// HandleStartBreak handles the player starting to break a block at the position passed. Private is true if the
+	// block is a private view-layer block, and false if it is the public world block. ctx.Cancel() may be called to
+	// stop the player from breaking the block completely.
+	HandleStartBreak(ctx *Context, pos cube.Pos, private bool)
+	// HandleBlockBreak handles a block that is being broken by a player. Private is true if the block broken is
+	// a private view-layer block, and false if it is the public world block. ctx.Cancel() may be called to cancel
+	// the block being broken. A pointer to a slice of the block's drops is passed, and may be altered to change
+	// what items will actually be dropped.
+	HandleBlockBreak(ctx *Context, pos cube.Pos, private bool, drops *[]item.Stack, xp *int)
 	// HandleBlockPlace handles the player placing a specific block at a position in its world. ctx.Cancel()
 	// may be called to cancel the block being placed.
 	HandleBlockPlace(ctx *Context, pos cube.Pos, b world.Block)
@@ -176,8 +178,8 @@ func (NopHandler) HandleTransfer(*Context, *net.UDPAddr)                        
 func (NopHandler) HandleChat(*Context, *string)                                            {}
 func (NopHandler) HandleSkinChange(*Context, *skin.Skin)                                   {}
 func (NopHandler) HandleFireExtinguish(*Context, cube.Pos)                                 {}
-func (NopHandler) HandleStartBreak(*Context, cube.Pos)                                     {}
-func (NopHandler) HandleBlockBreak(*Context, cube.Pos, *[]item.Stack, *int)                {}
+func (NopHandler) HandleStartBreak(*Context, cube.Pos, bool)                               {}
+func (NopHandler) HandleBlockBreak(*Context, cube.Pos, bool, *[]item.Stack, *int)          {}
 func (NopHandler) HandleBlockPlace(*Context, cube.Pos, world.Block)                        {}
 func (NopHandler) HandleBlockPick(*Context, cube.Pos, world.Block)                         {}
 func (NopHandler) HandleSignEdit(*Context, cube.Pos, bool, string, string)                 {}

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -67,15 +67,13 @@ type Handler interface {
 	// be called to cancel the fire being extinguished.
 	// cube.Pos can be used to see where was the fire extinguished, may be used to cancel this on specific positions.
 	HandleFireExtinguish(ctx *Context, pos cube.Pos)
-	// HandleStartBreak handles the player starting to break a block at the position passed. Private is true if the
-	// block is a private view-layer block, and false if it is the public world block. ctx.Cancel() may be called to
-	// stop the player from breaking the block completely.
-	HandleStartBreak(ctx *Context, pos cube.Pos, private bool)
-	// HandleBlockBreak handles a block that is being broken by a player. Private is true if the block broken is
-	// a private view-layer block, and false if it is the public world block. ctx.Cancel() may be called to cancel
+	// HandleStartBreak handles the player starting to break a block at the position passed. ctx.Cancel() may
+	// be called to stop the player from breaking the block completely.
+	HandleStartBreak(ctx *Context, pos cube.Pos)
+	// HandleBlockBreak handles a block that is being broken by a player. ctx.Cancel() may be called to cancel
 	// the block being broken. A pointer to a slice of the block's drops is passed, and may be altered to change
 	// what items will actually be dropped.
-	HandleBlockBreak(ctx *Context, pos cube.Pos, private bool, drops *[]item.Stack, xp *int)
+	HandleBlockBreak(ctx *Context, pos cube.Pos, drops *[]item.Stack, xp *int)
 	// HandleBlockPlace handles the player placing a specific block at a position in its world. ctx.Cancel()
 	// may be called to cancel the block being placed.
 	HandleBlockPlace(ctx *Context, pos cube.Pos, b world.Block)
@@ -178,8 +176,8 @@ func (NopHandler) HandleTransfer(*Context, *net.UDPAddr)                        
 func (NopHandler) HandleChat(*Context, *string)                                            {}
 func (NopHandler) HandleSkinChange(*Context, *skin.Skin)                                   {}
 func (NopHandler) HandleFireExtinguish(*Context, cube.Pos)                                 {}
-func (NopHandler) HandleStartBreak(*Context, cube.Pos, bool)                               {}
-func (NopHandler) HandleBlockBreak(*Context, cube.Pos, bool, *[]item.Stack, *int)          {}
+func (NopHandler) HandleStartBreak(*Context, cube.Pos)                                     {}
+func (NopHandler) HandleBlockBreak(*Context, cube.Pos, *[]item.Stack, *int)                {}
 func (NopHandler) HandleBlockPlace(*Context, cube.Pos, world.Block)                        {}
 func (NopHandler) HandleBlockPick(*Context, cube.Pos, world.Block)                         {}
 func (NopHandler) HandleSignEdit(*Context, cube.Pos, bool, string, string)                 {}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1512,7 +1512,7 @@ func (p *Player) UseItem() {
 	case item.Chargeable:
 		useCtx := p.useContext()
 		if !p.usingItem {
-			if !usable.ReleaseCharge(p, p.tx, useCtx) {
+			if !usable.ReleaseCharge(p, p.tx, useCtx) && usable.CanCharge(p, p.tx, useCtx) {
 				// If the item was not charged yet, start charging.
 				p.usingSince, p.usingItem = time.Now(), true
 			}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1861,17 +1861,20 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 		// The block was either out of range or air, so it can't be broken by the player.
 		return
 	}
-	if _, ok := p.tx.Block(pos.Side(face)).(block.Fire); ok && !private {
-		ctx := event.C(p)
-		if p.Handler().HandleFireExtinguish(ctx, pos); ctx.Cancelled() {
-			// Resend the block because on client side that was extinguished
-			p.resendNearbyBlocks(pos, face)
+	firePos := pos.Side(face)
+	if fireBlock, firePrivate := p.viewedBlock(firePos); !firePrivate {
+		if _, ok := fireBlock.(block.Fire); ok {
+			ctx := event.C(p)
+			if p.Handler().HandleFireExtinguish(ctx, pos); ctx.Cancelled() {
+				// Resend the block because on client side that was extinguished
+				p.resendNearbyBlocks(pos, face)
+				return
+			}
+
+			p.tx.SetBlock(firePos, nil, nil)
+			p.tx.PlaySound(pos.Vec3(), sound.FireExtinguish{})
 			return
 		}
-
-		p.tx.SetBlock(pos.Side(face), nil, nil)
-		p.tx.PlaySound(pos.Vec3(), sound.FireExtinguish{})
-		return
 	}
 
 	held, _ := p.HeldItems()

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1948,13 +1948,12 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 	}
 	pos := p.breakingPos
 	private := p.breakingPrivate
-	b := p.tx.Block(pos)
+	var b world.Block
 	if private {
 		b, _ = p.breakingBlock(pos)
-	}
-	if private {
 		p.ShowParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
 	} else {
+		b = p.tx.Block(pos)
 		p.tx.AddParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
 	}
 

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2046,32 +2046,10 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 // reach the block passed, the method returns immediately.
 func (p *Player) BreakBlock(pos cube.Pos) {
 	b := p.tx.Block(pos)
-	if privateBlock, private := p.privateBlock(pos); private {
-		held, _ := p.HeldItems()
-		drops := p.drops(held, privateBlock)
-		xp := 0
-		if breakable, ok := privateBlock.(block.Breakable); ok && !p.GameMode().CreativeInventory() {
-			if _, hasSilkTouch := held.Enchantment(enchantment.SilkTouch); !hasSilkTouch {
-				xp = breakable.BreakInfo().XPDrops.RandomValue()
-			}
-		}
 
-		ctx := event.C(p)
-		if p.Handler().HandleBlockBreak(ctx, pos, true, &drops, &xp); ctx.Cancelled() {
-			p.resendNearbyBlocks(pos)
-			return
-		}
-		p.SwingArm()
-		p.ViewPublicBlock(pos)
-		p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: privateBlock})
-		for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
-			p.tx.AddEntity(orb)
-		}
-		for _, drop := range drops {
-			opts := world.EntitySpawnOpts{Position: pos.Vec3Centre(), Velocity: mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1}}
-			p.tx.AddEntity(entity.NewItem(opts, drop))
-		}
-		return
+	privateBlock, private := p.privateBlock(pos)
+	if private {
+		b = privateBlock
 	}
 	if _, air := b.(block.Air); air {
 		// Don't do anything if the position broken is already air.
@@ -2096,21 +2074,31 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	}
 
 	ctx := event.C(p)
-	if p.Handler().HandleBlockBreak(ctx, pos, false, &drops, &xp); ctx.Cancelled() {
+	if p.Handler().HandleBlockBreak(ctx, pos, private, &drops, &xp); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos)
 		return
 	}
 	held, left := p.HeldItems()
 
 	p.SwingArm()
-	p.tx.SetBlock(pos, nil, nil)
+	if private {
+		p.ViewPublicBlock(pos)
+	} else {
+		p.tx.SetBlock(pos, nil, nil)
+
+		if breakable, ok := b.(block.Breakable); ok {
+			info := breakable.BreakInfo()
+			if info.BreakHandler != nil {
+				info.BreakHandler(pos, p.tx, p)
+			}
+			for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
+				p.tx.AddEntity(orb)
+			}
+		}
+	}
 	p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 
-	if breakable, ok := b.(block.Breakable); ok {
-		info := breakable.BreakInfo()
-		if info.BreakHandler != nil {
-			info.BreakHandler(pos, p.tx, p)
-		}
+	if private {
 		for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
 			p.tx.AddEntity(orb)
 		}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1844,7 +1844,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 		// The block was either out of range or air, so it can't be broken by the player.
 		return
 	}
-	if _, ok := p.tx.Block(pos.Side(face)).(block.Fire); ok {
+	if _, ok := p.tx.Block(pos.Side(face)).(block.Fire); ok && !private {
 		ctx := event.C(p)
 		if p.Handler().HandleFireExtinguish(ctx, pos); ctx.Cancelled() {
 			// Resend the block because on client side that was extinguished
@@ -1867,7 +1867,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	p.breakingPos = pos
 
 	ctx := event.C(p)
-	if p.Handler().HandleStartBreak(ctx, pos, private); ctx.Cancelled() {
+	if p.Handler().HandleStartBreak(ctx, pos); ctx.Cancelled() {
 		return
 	}
 	if punchable, ok := b.(block.Punchable); ok && !private {
@@ -2080,17 +2080,20 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 		return
 	}
 	held, _ := p.HeldItems()
-	drops := p.drops(held, b)
+	var drops []item.Stack
 
 	xp := 0
-	if breakable, ok := b.(block.Breakable); ok && !p.GameMode().CreativeInventory() {
-		if _, hasSilkTouch := held.Enchantment(enchantment.SilkTouch); !hasSilkTouch {
-			xp = breakable.BreakInfo().XPDrops.RandomValue()
+	if !private {
+		drops = p.drops(held, b)
+		if breakable, ok := b.(block.Breakable); ok && !p.GameMode().CreativeInventory() {
+			if _, hasSilkTouch := held.Enchantment(enchantment.SilkTouch); !hasSilkTouch {
+				xp = breakable.BreakInfo().XPDrops.RandomValue()
+			}
 		}
 	}
 
 	ctx := event.C(p)
-	if p.Handler().HandleBlockBreak(ctx, pos, private, &drops, &xp); ctx.Cancelled() {
+	if p.Handler().HandleBlockBreak(ctx, pos, &drops, &xp); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos)
 		return
 	}
@@ -2100,6 +2103,7 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	if private {
 		p.ViewPublicBlock(pos)
 		p.s.ViewParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
+		return
 	} else {
 		p.tx.SetBlock(pos, nil, nil)
 		p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
@@ -2160,7 +2164,7 @@ func (p *Player) PickBlock(pos cube.Pos) {
 		return
 	}
 
-	b := p.tx.Block(pos)
+	b := p.breakingBlock(pos)
 
 	var pickedItem item.Stack
 	if pi, ok := b.(block.Pickable); ok {
@@ -2664,6 +2668,9 @@ func (p *Player) ViewBlock(pos cube.Pos, b world.Block) {
 // ViewPublicBlock removes the block override at the position passed for this player.
 func (p *Player) ViewPublicBlock(pos cube.Pos) {
 	p.session().ViewPublicBlock(pos)
+	if p.session() != session.Nop && !pos.OutOfBounds(p.tx.Range()) {
+		p.session().ViewBlockUpdate(pos, p.tx.Block(pos), 0)
+	}
 }
 
 // RemoveViewLayer removes all view-layer overrides of the entity for this player.

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1992,7 +1992,7 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 // block, or to all viewers if it is a public world block.
 func (p *Player) viewBreakingBlockAction(pos cube.Pos, private bool, a world.BlockAction) {
 	if private {
-		p.session().ViewBlockAction(pos, a)
+		p.session().ViewPrivateBlockAction(pos, a)
 		return
 	}
 	for _, viewer := range p.viewers() {

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2083,8 +2083,10 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	p.SwingArm()
 	if private {
 		p.ViewPublicBlock(pos)
+		p.s.ViewParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 	} else {
 		p.tx.SetBlock(pos, nil, nil)
+		p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 	}
 
 	if breakable, ok := b.(block.Breakable); ok {
@@ -2094,7 +2096,6 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 		}
 	}
 
-	p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 	for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
 		p.tx.AddEntity(orb)
 	}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2091,17 +2091,12 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 			if info.BreakHandler != nil {
 				info.BreakHandler(pos, p.tx, p)
 			}
-			for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
-				p.tx.AddEntity(orb)
-			}
 		}
 	}
 	p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 
-	if private {
-		for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
-			p.tx.AddEntity(orb)
-		}
+	for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
+		p.tx.AddEntity(orb)
 	}
 	for _, drop := range drops {
 		opts := world.EntitySpawnOpts{Position: pos.Vec3Centre(), Velocity: mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1}}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1838,10 +1838,9 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 // player might be breaking before this method is called.
 func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	p.AbortBreaking()
-	if _, air := p.tx.Block(pos).(block.Air); air || !p.canReach(pos.Vec3Centre()) {
-		if air && p.viewLayerBlock(pos) {
-			p.resendNearbyBlocks(pos)
-		}
+	b := p.breakingBlock(pos)
+	_, private := p.privateBlock(pos)
+	if _, air := b.(block.Air); air || !p.canReach(pos.Vec3Centre()) {
 		// The block was either out of range or air, so it can't be broken by the player.
 		return
 	}
@@ -1868,10 +1867,10 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	p.breakingPos = pos
 
 	ctx := event.C(p)
-	if p.Handler().HandleStartBreak(ctx, pos); ctx.Cancelled() {
+	if p.Handler().HandleStartBreak(ctx, pos, private); ctx.Cancelled() {
 		return
 	}
-	if punchable, ok := p.tx.Block(pos).(block.Punchable); ok {
+	if punchable, ok := b.(block.Punchable); ok {
 		punchable.Punch(pos, face, p.tx, p)
 	}
 
@@ -1881,7 +1880,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	if p.GameMode().CreativeInventory() {
 		return
 	}
-	p.lastBreakDuration = p.breakTime(pos)
+	p.lastBreakDuration = p.breakTime(b)
 	for _, viewer := range p.viewers() {
 		viewer.ViewBlockAction(pos, block.StartCrackAction{BreakTime: p.lastBreakDuration})
 	}
@@ -1889,9 +1888,9 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 
 // breakTime returns the time needed to break a block at the position passed, taking into account the item
 // held, if the player is on the ground/underwater and if the player has any effects.
-func (p *Player) breakTime(pos cube.Pos) time.Duration {
+func (p *Player) breakTime(b world.Block) time.Duration {
 	held, _ := p.HeldItems()
-	breakTime := block.BreakDuration(p.tx.Block(pos), held)
+	breakTime := block.BreakDuration(b, held)
 	if !p.OnGround() {
 		breakTime *= 5
 	}
@@ -1917,6 +1916,10 @@ func (p *Player) breakTime(pos cube.Pos) time.Duration {
 // FinishBreaking will stop the animation and break the block.
 func (p *Player) FinishBreaking() {
 	if !p.breaking {
+		if _, private := p.privateBlock(p.breakingPos); private {
+			p.BreakBlock(p.breakingPos)
+			return
+		}
 		p.resendNearbyBlock(p.breakingPos)
 		return
 	}
@@ -1945,7 +1948,7 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 		return
 	}
 	pos := p.breakingPos
-	b := p.tx.Block(pos)
+	b := p.breakingBlock(pos)
 	p.tx.AddParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
 
 	if p.breakCounter++; p.breakCounter%5 == 0 {
@@ -1955,12 +1958,20 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 		// either. Every 5 ticks seems accurate.
 		p.tx.PlaySound(pos.Vec3(), sound.BlockBreaking{Block: b})
 	}
-	if breakTime := p.breakTime(pos); breakTime != p.lastBreakDuration {
+	if breakTime := p.breakTime(b); breakTime != p.lastBreakDuration {
 		for _, viewer := range p.viewers() {
 			viewer.ViewBlockAction(pos, block.ContinueCrackAction{BreakTime: breakTime})
 		}
 		p.lastBreakDuration = breakTime
 	}
+}
+
+// breakingBlock returns the block that should be used for the player's breaking progress.
+func (p *Player) breakingBlock(pos cube.Pos) world.Block {
+	if b, ok := p.privateBlock(pos); ok {
+		return b
+	}
+	return p.tx.Block(pos)
 }
 
 // PlaceBlock makes the player place the block passed at the position passed, granted it is within the range
@@ -2039,10 +2050,21 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 // reach the block passed, the method returns immediately.
 func (p *Player) BreakBlock(pos cube.Pos) {
 	b := p.tx.Block(pos)
-	if _, air := b.(block.Air); air {
-		if p.viewLayerBlock(pos) {
+	if privateBlock, private := p.privateBlock(pos); private {
+		var drops []item.Stack
+		xp := 0
+
+		ctx := event.C(p)
+		if p.Handler().HandleBlockBreak(ctx, pos, true, &drops, &xp); ctx.Cancelled() {
 			p.resendNearbyBlocks(pos)
+			return
 		}
+		p.SwingArm()
+		p.ViewPublicBlock(pos)
+		p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: privateBlock})
+		return
+	}
+	if _, air := b.(block.Air); air {
 		// Don't do anything if the position broken is already air.
 		return
 	}
@@ -2065,7 +2087,7 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	}
 
 	ctx := event.C(p)
-	if p.Handler().HandleBlockBreak(ctx, pos, &drops, &xp); ctx.Cancelled() {
+	if p.Handler().HandleBlockBreak(ctx, pos, false, &drops, &xp); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos)
 		return
 	}
@@ -2115,13 +2137,12 @@ func (p *Player) drops(held item.Stack, b world.Block) []item.Stack {
 	return drops
 }
 
-// viewLayerBlock checks if this player has a view-layer block override at pos.
-func (p *Player) viewLayerBlock(pos cube.Pos) bool {
+// privateBlock returns this player's view-layer block override at pos, if present.
+func (p *Player) privateBlock(pos cube.Pos) (world.Block, bool) {
 	if p.session() == session.Nop {
-		return false
+		return nil, false
 	}
-	_, ok := p.ViewLayer().Block(pos)
-	return ok
+	return p.ViewLayer().Block(pos)
 }
 
 // PickBlock makes the player pick a block in the world at a position passed. If the player is unable to

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2612,6 +2612,16 @@ func (p *Player) ViewVisibility(entity world.Entity, level world.VisibilityLevel
 	p.session().ViewVisibility(entity, level)
 }
 
+// ViewBlock overrides the public block at the position passed for this player.
+func (p *Player) ViewBlock(pos cube.Pos, b world.Block) {
+	p.session().ViewBlock(pos, b)
+}
+
+// ViewPublicBlock removes the block override at the position passed for this player.
+func (p *Player) ViewPublicBlock(pos cube.Pos) {
+	p.session().ViewPublicBlock(pos)
+}
+
 // RemoveViewLayer removes all view-layer overrides of the entity for this player.
 func (p *Player) RemoveViewLayer(entity world.Entity) {
 	p.session().RemoveViewLayer(entity)

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1668,7 +1668,7 @@ func (p *Player) UsingItem() bool {
 // returns immediately.
 // UseItemOnBlock does nothing if the block at the cube.Pos passed is of the type block.Air.
 func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec3) {
-	b, private := p.viewedBlock(pos)
+	b, _ := p.viewedBlock(pos)
 	if _, ok := b.(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
 		// The client used its item on a block that does not exist server-side or one it couldn't reach. Stop trying
 		// to use the item immediately.
@@ -1680,7 +1680,7 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 		p.resendNearbyBlocks(pos, face)
 		return
 	}
-	b, private = p.viewedBlock(pos)
+	b, private := p.viewedBlock(pos)
 	if _, ok := b.(block.Air); ok {
 		p.resendNearbyBlocks(pos, face)
 		return

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1859,12 +1859,17 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 		return
 	}
 	firePos := pos.Side(face)
-	if fireBlock, firePrivate := p.viewedBlock(firePos); !firePrivate {
+	if fireBlock, firePrivate := p.viewedBlock(firePos); fireBlock != nil {
 		if _, ok := fireBlock.(block.Fire); ok {
 			ctx := event.C(p)
 			if p.Handler().HandleFireExtinguish(ctx, pos); ctx.Cancelled() {
 				// Resend the block because on client side that was extinguished
 				p.resendNearbyBlocks(pos, face)
+				return
+			}
+			if firePrivate {
+				p.ViewPublicBlock(firePos)
+				p.session().ViewSound(pos.Vec3(), sound.FireExtinguish{})
 				return
 			}
 

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1916,10 +1916,6 @@ func (p *Player) breakTime(b world.Block) time.Duration {
 // FinishBreaking will stop the animation and break the block.
 func (p *Player) FinishBreaking() {
 	if !p.breaking {
-		if _, private := p.privateBlock(p.breakingPos); private {
-			p.BreakBlock(p.breakingPos)
-			return
-		}
 		p.resendNearbyBlock(p.breakingPos)
 		return
 	}
@@ -2051,8 +2047,14 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 func (p *Player) BreakBlock(pos cube.Pos) {
 	b := p.tx.Block(pos)
 	if privateBlock, private := p.privateBlock(pos); private {
-		var drops []item.Stack
+		held, _ := p.HeldItems()
+		drops := p.drops(held, privateBlock)
 		xp := 0
+		if breakable, ok := privateBlock.(block.Breakable); ok && !p.GameMode().CreativeInventory() {
+			if _, hasSilkTouch := held.Enchantment(enchantment.SilkTouch); !hasSilkTouch {
+				xp = breakable.BreakInfo().XPDrops.RandomValue()
+			}
+		}
 
 		ctx := event.C(p)
 		if p.Handler().HandleBlockBreak(ctx, pos, true, &drops, &xp); ctx.Cancelled() {
@@ -2062,6 +2064,13 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 		p.SwingArm()
 		p.ViewPublicBlock(pos)
 		p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: privateBlock})
+		for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
+			p.tx.AddEntity(orb)
+		}
+		for _, drop := range drops {
+			opts := world.EntitySpawnOpts{Position: pos.Vec3Centre(), Velocity: mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1}}
+			p.tx.AddEntity(entity.NewItem(opts, drop))
+		}
 		return
 	}
 	if _, air := b.(block.Air); air {

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1664,7 +1664,7 @@ func (p *Player) UsingItem() bool {
 // returns immediately.
 // UseItemOnBlock does nothing if the block at the cube.Pos passed is of the type block.Air.
 func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec3) {
-	b, _ := p.viewedBlock(pos)
+	b, private := p.viewedBlock(pos)
 	if _, ok := b.(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
 		// The client used its item on a block that does not exist server-side or one it couldn't reach. Stop trying
 		// to use the item immediately.
@@ -1674,6 +1674,9 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 	ctx := event.C(p)
 	if p.Handler().HandleItemUseOnBlock(ctx, pos, face, clickPos); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos, face)
+		return
+	}
+	if private {
 		return
 	}
 	i, left := p.HeldItems()
@@ -1712,7 +1715,10 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 			// The block clicked was either not replaceable, or not replaceable using the block passed.
 			replacedPos = pos.Side(face)
 		}
-		replacedBlock, _ := p.viewedBlock(replacedPos)
+		replacedBlock, replacedPrivate := p.viewedBlock(replacedPos)
+		if replacedPrivate {
+			return
+		}
 		if replaceable, ok := replacedBlock.(block.Replaceable); !ok || !replaceable.ReplaceableBy(ib) || replacedPos.OutOfBounds(p.tx.Range()) {
 			return
 		}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1669,13 +1669,8 @@ func (p *Player) UsingItem() bool {
 // UseItemOnBlock does nothing if the block at the cube.Pos passed is of the type block.Air.
 func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec3) {
 	b, private := p.viewedBlock(pos)
-	if _, ok := b.(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
-		// The client used its item on a block that does not exist server-side or one it couldn't reach. Stop trying
-		// to use the item immediately.
-		p.resendNearbyBlocks(pos, face)
-		return
-	}
-	if private {
+	if _, ok := b.(block.Air); ok || private || !p.canReach(pos.Vec3Centre()) {
+		// The client used its item on a block that cannot be interacted with. Stop trying to use the item immediately.
 		p.resendNearbyBlocks(pos, face)
 		return
 	}
@@ -1685,11 +1680,7 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 		return
 	}
 	b, private = p.viewedBlock(pos)
-	if _, ok := b.(block.Air); ok {
-		p.resendNearbyBlocks(pos, face)
-		return
-	}
-	if private {
+	if _, ok := b.(block.Air); ok || private {
 		p.resendNearbyBlocks(pos, face)
 		return
 	}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1854,30 +1854,29 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 // player might be breaking before this method is called.
 func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	p.AbortBreaking()
-	b, private := p.breakingBlock(pos)
+	b, private := p.viewedBlock(pos)
 	if _, air := b.(block.Air); air || !p.canReach(pos.Vec3Centre()) {
 		// The block was either out of range or air, so it can't be broken by the player.
 		return
 	}
 	firePos := pos.Side(face)
-	if fireBlock, firePrivate := p.viewedBlock(firePos); fireBlock != nil {
-		if _, ok := fireBlock.(block.Fire); ok {
-			ctx := event.C(p)
-			if p.Handler().HandleFireExtinguish(ctx, pos); ctx.Cancelled() {
-				// Resend the block because on client side that was extinguished
-				p.resendNearbyBlocks(pos, face)
-				return
-			}
-			if firePrivate {
-				p.ViewPublicBlock(firePos)
-				p.session().ViewSound(pos.Vec3(), sound.FireExtinguish{})
-				return
-			}
-
-			p.tx.SetBlock(firePos, nil, nil)
-			p.tx.PlaySound(pos.Vec3(), sound.FireExtinguish{})
+	fireBlock, firePrivate := p.viewedBlock(firePos)
+	if _, ok := fireBlock.(block.Fire); ok {
+		ctx := event.C(p)
+		if p.Handler().HandleFireExtinguish(ctx, pos); ctx.Cancelled() {
+			// Resend the block because on client side that was extinguished
+			p.resendNearbyBlocks(pos, face)
 			return
 		}
+		if firePrivate {
+			p.ViewPublicBlock(firePos)
+			p.session().ViewSound(pos.Vec3(), sound.FireExtinguish{})
+			return
+		}
+
+		p.tx.SetBlock(firePos, nil, nil)
+		p.tx.PlaySound(pos.Vec3(), sound.FireExtinguish{})
+		return
 	}
 
 	held, _ := p.HeldItems()
@@ -1897,7 +1896,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 		punchable.Punch(pos, face, p.tx, p)
 	}
 
-	p.breaking, p.breakingFace, p.breakingPrivate = true, face, private
+	p.breaking, p.breakingFace = true, face
 	p.SwingArm()
 
 	if p.GameMode().CreativeInventory() {
@@ -1947,14 +1946,12 @@ func (p *Player) FinishBreaking() {
 	private := p.breakingPrivate
 	p.AbortBreaking()
 	if private {
-		if b, ok := p.privateBlock(pos); ok {
-			p.breakBlock(pos, b, true)
-		} else {
+		if _, ok := p.privateBlock(pos); !ok {
 			p.resendBreakingBlock(pos, false)
+			return
 		}
-		return
 	}
-	p.BreakBlock(pos)
+	p.BreakViewedBlock(pos)
 }
 
 // AbortBreaking makes the player stop breaking the block it is currently breaking, or returns immediately
@@ -2019,21 +2016,8 @@ func (p *Player) viewBreakingBlockAction(pos cube.Pos, private bool, a world.Blo
 		return
 	}
 	for _, viewer := range p.viewers() {
-		if viewerHasPrivateBlock(viewer, pos) {
-			continue
-		}
 		viewer.ViewBlockAction(pos, a)
 	}
-}
-
-// viewerHasPrivateBlock returns true if the viewer has a private block override at pos.
-func viewerHasPrivateBlock(viewer world.Viewer, pos cube.Pos) bool {
-	s, ok := viewer.(*session.Session)
-	if !ok || s.ViewLayer() == nil {
-		return false
-	}
-	_, ok = s.ViewLayer().Block(pos)
-	return ok
 }
 
 // viewedBlock returns the block currently shown to the player at pos.
@@ -2042,11 +2026,6 @@ func (p *Player) viewedBlock(pos cube.Pos) (world.Block, bool) {
 		return b, true
 	}
 	return p.tx.Block(pos), false
-}
-
-// breakingBlock returns the block that should be used for the player's breaking progress.
-func (p *Player) breakingBlock(pos cube.Pos) (world.Block, bool) {
-	return p.viewedBlock(pos)
 }
 
 // PlaceBlock makes the player place the block passed at the position passed, granted it is within the range
@@ -2132,7 +2111,7 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 // player has a private block override at that position, it is removed instead of breaking the public world block.
 // If the player is unable to reach the block passed, the method returns immediately.
 func (p *Player) BreakViewedBlock(pos cube.Pos) {
-	b, private := p.breakingBlock(pos)
+	b, private := p.viewedBlock(pos)
 	p.breakBlock(pos, b, private)
 }
 
@@ -2150,7 +2129,8 @@ func (p *Player) breakBlock(pos cube.Pos, b world.Block, private bool) {
 		resendBrokenBlock()
 		return
 	}
-	if _, breakable := b.(block.Breakable); !breakable && !p.GameMode().CreativeInventory() {
+	breakable, ok := b.(block.Breakable)
+	if !ok && !p.GameMode().CreativeInventory() {
 		resendBrokenBlock()
 		return
 	}
@@ -2160,7 +2140,7 @@ func (p *Player) breakBlock(pos cube.Pos, b world.Block, private bool) {
 	xp := 0
 	if !private {
 		drops = p.drops(held, b)
-		if breakable, ok := b.(block.Breakable); ok && !p.GameMode().CreativeInventory() {
+		if ok && !p.GameMode().CreativeInventory() {
 			if _, hasSilkTouch := held.Enchantment(enchantment.SilkTouch); !hasSilkTouch {
 				xp = breakable.BreakInfo().XPDrops.RandomValue()
 			}
@@ -2179,18 +2159,14 @@ func (p *Player) breakBlock(pos cube.Pos, b world.Block, private bool) {
 		p.ViewPublicBlock(pos)
 		p.ShowParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 		return
-	} else {
-		p.tx.SetBlock(pos, nil, nil)
-		p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
-		if breakable, ok := b.(block.Breakable); ok {
-			info := breakable.BreakInfo()
-			if info.BreakHandler != nil {
-				info.BreakHandler(pos, p.tx, p)
-			}
-		}
 	}
-
-	if _, ok := b.(block.Breakable); ok {
+	p.tx.SetBlock(pos, nil, nil)
+	p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
+	if ok {
+		info := breakable.BreakInfo()
+		if info.BreakHandler != nil {
+			info.BreakHandler(pos, p.tx, p)
+		}
 		for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
 			p.tx.AddEntity(orb)
 		}
@@ -2250,7 +2226,7 @@ func (p *Player) PickBlock(pos cube.Pos) {
 		return
 	}
 
-	b, _ := p.breakingBlock(pos)
+	b, _ := p.viewedBlock(pos)
 
 	var pickedItem item.Stack
 	if pi, ok := b.(block.Pickable); ok {

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2122,8 +2122,10 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 		}
 	}
 
-	for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
-		p.tx.AddEntity(orb)
+	if _, ok := b.(block.Breakable); ok {
+		for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
+			p.tx.AddEntity(orb)
+		}
 	}
 	for _, drop := range drops {
 		opts := world.EntitySpawnOpts{Position: pos.Vec3Centre(), Velocity: mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1}}
@@ -2684,9 +2686,6 @@ func (p *Player) ViewBlock(pos cube.Pos, b world.Block) {
 // ViewPublicBlock removes the block override at the position passed for this player.
 func (p *Player) ViewPublicBlock(pos cube.Pos) {
 	p.session().ViewPublicBlock(pos)
-	if p.session() != session.Nop && !pos.OutOfBounds(p.tx.Range()) {
-		p.session().ViewBlockUpdate(pos, p.tx.Block(pos), 0)
-	}
 }
 
 // RemoveViewLayer removes all view-layer overrides of the entity for this player.

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2087,12 +2087,11 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	} else {
 		p.tx.SetBlock(pos, nil, nil)
 		p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
-	}
-
-	if breakable, ok := b.(block.Breakable); ok {
-		info := breakable.BreakInfo()
-		if info.BreakHandler != nil {
-			info.BreakHandler(pos, p.tx, p)
+		if breakable, ok := b.(block.Breakable); ok  {
+			info := breakable.BreakInfo()
+			if info.BreakHandler != nil {
+				info.BreakHandler(pos, p.tx, p)
+			}
 		}
 	}
 

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1686,6 +1686,7 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 		return
 	}
 	if private {
+		p.resendNearbyBlocks(pos, face)
 		return
 	}
 	i, left := p.HeldItems()
@@ -1726,6 +1727,7 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 		}
 		replacedBlock, replacedPrivate := p.viewedBlock(replacedPos)
 		if replacedPrivate {
+			p.resendNearbyBlocks(replacedPos)
 			return
 		}
 		if replaceable, ok := replacedBlock.(block.Replaceable); !ok || !replaceable.ReplaceableBy(ib) || replacedPos.OutOfBounds(p.tx.Range()) {
@@ -2112,10 +2114,17 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 	return obstructed, true
 }
 
-// BreakBlock makes the player break a block at a position passed. If the player has a private block
-// override at that position, it is removed instead of breaking the public world block. If the player is
-// unable to reach the block passed, the method returns immediately.
+// BreakBlock makes the player break the public world block at the position passed. Private view-layer
+// overrides are ignored by this method: Call BreakViewedBlock to break what the player currently sees instead.
+// If the player is unable to reach the block passed, the method returns immediately.
 func (p *Player) BreakBlock(pos cube.Pos) {
+	p.breakBlock(pos, p.tx.Block(pos), false)
+}
+
+// BreakViewedBlock makes the player break the block currently shown to them at the position passed. If the
+// player has a private block override at that position, it is removed instead of breaking the public world block.
+// If the player is unable to reach the block passed, the method returns immediately.
+func (p *Player) BreakViewedBlock(pos cube.Pos) {
 	b, private := p.breakingBlock(pos)
 	p.breakBlock(pos, b, private)
 }

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1680,6 +1680,11 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 		p.resendNearbyBlocks(pos, face)
 		return
 	}
+	b, private = p.viewedBlock(pos)
+	if _, ok := b.(block.Air); ok {
+		p.resendNearbyBlocks(pos, face)
+		return
+	}
 	if private {
 		return
 	}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1664,7 +1664,8 @@ func (p *Player) UsingItem() bool {
 // returns immediately.
 // UseItemOnBlock does nothing if the block at the cube.Pos passed is of the type block.Air.
 func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec3) {
-	if _, ok := p.tx.Block(pos).(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
+	b, _ := p.viewedBlock(pos)
+	if _, ok := b.(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
 		// The client used its item on a block that does not exist server-side or one it couldn't reach. Stop trying
 		// to use the item immediately.
 		p.resendNearbyBlocks(pos, face)
@@ -1676,7 +1677,6 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 		return
 	}
 	i, left := p.HeldItems()
-	b := p.tx.Block(pos)
 	if act, ok := b.(block.Activatable); ok {
 		// If a player is sneaking, it will not activate the block clicked, unless it is not holding any
 		// items, in which case the block will be activated as usual.
@@ -1712,7 +1712,8 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 			// The block clicked was either not replaceable, or not replaceable using the block passed.
 			replacedPos = pos.Side(face)
 		}
-		if replaceable, ok := p.tx.Block(replacedPos).(block.Replaceable); !ok || !replaceable.ReplaceableBy(ib) || replacedPos.OutOfBounds(p.tx.Range()) {
+		replacedBlock, _ := p.viewedBlock(replacedPos)
+		if replaceable, ok := replacedBlock.(block.Replaceable); !ok || !replaceable.ReplaceableBy(ib) || replacedPos.OutOfBounds(p.tx.Range()) {
 			return
 		}
 		if !p.placeBlock(replacedPos, ib, false) || p.GameMode().CreativeInventory() {
@@ -1922,7 +1923,14 @@ func (p *Player) FinishBreaking() {
 		return
 	}
 	pos := p.breakingPos
+	private := p.breakingPrivate
 	p.AbortBreaking()
+	if private {
+		if b, ok := p.privateBlock(pos); ok {
+			p.breakBlock(pos, b, true)
+		}
+		return
+	}
 	p.BreakBlock(pos)
 }
 
@@ -1999,12 +2007,17 @@ func viewerHasPrivateBlock(viewer world.Viewer, pos cube.Pos) bool {
 	return ok
 }
 
-// breakingBlock returns the block that should be used for the player's breaking progress.
-func (p *Player) breakingBlock(pos cube.Pos) (world.Block, bool) {
+// viewedBlock returns the block currently shown to the player at pos.
+func (p *Player) viewedBlock(pos cube.Pos) (world.Block, bool) {
 	if b, ok := p.privateBlock(pos); ok {
 		return b, true
 	}
 	return p.tx.Block(pos), false
+}
+
+// breakingBlock returns the block that should be used for the player's breaking progress.
+func (p *Player) breakingBlock(pos cube.Pos) (world.Block, bool) {
+	return p.viewedBlock(pos)
 }
 
 // PlaceBlock makes the player place the block passed at the position passed, granted it is within the range

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1870,7 +1870,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	if p.Handler().HandleStartBreak(ctx, pos, private); ctx.Cancelled() {
 		return
 	}
-	if punchable, ok := b.(block.Punchable); ok {
+	if punchable, ok := b.(block.Punchable); ok && !private {
 		punchable.Punch(pos, face, p.tx, p)
 	}
 
@@ -1881,9 +1881,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 		return
 	}
 	p.lastBreakDuration = p.breakTime(b)
-	for _, viewer := range p.viewers() {
-		viewer.ViewBlockAction(pos, block.StartCrackAction{BreakTime: p.lastBreakDuration})
-	}
+	p.viewBreakingBlockAction(pos, private, block.StartCrackAction{BreakTime: p.lastBreakDuration})
 }
 
 // breakTime returns the time needed to break a block at the position passed, taking into account the item
@@ -1930,10 +1928,9 @@ func (p *Player) AbortBreaking() {
 	if !p.breaking {
 		return
 	}
+	_, private := p.privateBlock(p.breakingPos)
 	p.breaking, p.breakCounter = false, 0
-	for _, viewer := range p.viewers() {
-		viewer.ViewBlockAction(p.breakingPos, block.StopCrackAction{})
-	}
+	p.viewBreakingBlockAction(p.breakingPos, private, block.StopCrackAction{})
 }
 
 // ContinueBreaking makes the player continue breaking the block it started breaking after a call to
@@ -1945,20 +1942,39 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 	}
 	pos := p.breakingPos
 	b := p.breakingBlock(pos)
-	p.tx.AddParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
+	_, private := p.privateBlock(pos)
+	if private {
+		p.s.ViewParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
+	} else {
+		p.tx.AddParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
+	}
 
 	if p.breakCounter++; p.breakCounter%5 == 0 {
 		p.SwingArm()
 
 		// We send this sound only every so often. Vanilla doesn't send it every tick while breaking
 		// either. Every 5 ticks seems accurate.
-		p.tx.PlaySound(pos.Vec3(), sound.BlockBreaking{Block: b})
+		if private {
+			p.s.ViewSound(pos.Vec3(), sound.BlockBreaking{Block: b})
+		} else {
+			p.tx.PlaySound(pos.Vec3(), sound.BlockBreaking{Block: b})
+		}
 	}
 	if breakTime := p.breakTime(b); breakTime != p.lastBreakDuration {
-		for _, viewer := range p.viewers() {
-			viewer.ViewBlockAction(pos, block.ContinueCrackAction{BreakTime: breakTime})
-		}
+		p.viewBreakingBlockAction(pos, private, block.ContinueCrackAction{BreakTime: breakTime})
 		p.lastBreakDuration = breakTime
+	}
+}
+
+// viewBreakingBlockAction shows a breaking action to the player only if the block is a private view-layer
+// block, or to all viewers if it is a public world block.
+func (p *Player) viewBreakingBlockAction(pos cube.Pos, private bool, a world.BlockAction) {
+	if private {
+		p.s.ViewBlockAction(pos, a)
+		return
+	}
+	for _, viewer := range p.viewers() {
+		viewer.ViewBlockAction(pos, a)
 	}
 }
 
@@ -2087,7 +2103,7 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	} else {
 		p.tx.SetBlock(pos, nil, nil)
 		p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
-		if breakable, ok := b.(block.Breakable); ok  {
+		if breakable, ok := b.(block.Breakable); ok {
 			info := breakable.BreakInfo()
 			if info.BreakHandler != nil {
 				info.BreakHandler(pos, p.tx, p)

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1668,7 +1668,8 @@ func (p *Player) UsingItem() bool {
 // returns immediately.
 // UseItemOnBlock does nothing if the block at the cube.Pos passed is of the type block.Air.
 func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec3) {
-	b, private := p.viewedBlock(pos)
+	b, _ := p.viewedBlock(pos)
+	var private bool
 	if _, ok := b.(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
 		// The client used its item on a block that cannot be interacted with. Stop trying to use the item immediately.
 		p.resendNearbyBlocks(pos, face)

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1669,7 +1669,7 @@ func (p *Player) UsingItem() bool {
 // UseItemOnBlock does nothing if the block at the cube.Pos passed is of the type block.Air.
 func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec3) {
 	b, private := p.viewedBlock(pos)
-	if _, ok := b.(block.Air); ok || private || !p.canReach(pos.Vec3Centre()) {
+	if _, ok := b.(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
 		// The client used its item on a block that cannot be interacted with. Stop trying to use the item immediately.
 		p.resendNearbyBlocks(pos, face)
 		return

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2037,6 +2037,9 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 func (p *Player) BreakBlock(pos cube.Pos) {
 	b := p.tx.Block(pos)
 	if _, air := b.(block.Air); air {
+		if p.viewLayerBlock(pos) {
+			p.resendNearbyBlocks(pos)
+		}
 		// Don't do anything if the position broken is already air.
 		return
 	}
@@ -2107,6 +2110,15 @@ func (p *Player) drops(held item.Stack, b world.Block) []item.Stack {
 		drops = []item.Stack{item.NewStack(it, 1)}
 	}
 	return drops
+}
+
+// viewLayerBlock checks if this player has a view-layer block override at pos.
+func (p *Player) viewLayerBlock(pos cube.Pos) bool {
+	if p.session() == session.Nop {
+		return false
+	}
+	_, ok := p.ViewLayer().Block(pos)
+	return ok
 }
 
 // PickBlock makes the player pick a block in the world at a position passed. If the player is unable to

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1668,10 +1668,14 @@ func (p *Player) UsingItem() bool {
 // returns immediately.
 // UseItemOnBlock does nothing if the block at the cube.Pos passed is of the type block.Air.
 func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec3) {
-	b, _ := p.viewedBlock(pos)
+	b, private := p.viewedBlock(pos)
 	if _, ok := b.(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
 		// The client used its item on a block that does not exist server-side or one it couldn't reach. Stop trying
 		// to use the item immediately.
+		p.resendNearbyBlocks(pos, face)
+		return
+	}
+	if private {
 		p.resendNearbyBlocks(pos, face)
 		return
 	}
@@ -1680,7 +1684,7 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 		p.resendNearbyBlocks(pos, face)
 		return
 	}
-	b, private := p.viewedBlock(pos)
+	b, private = p.viewedBlock(pos)
 	if _, ok := b.(block.Air); ok {
 		p.resendNearbyBlocks(pos, face)
 		return
@@ -1980,7 +1984,13 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 	private := p.breakingPrivate
 	var b world.Block
 	if private {
-		b, _ = p.breakingBlock(pos)
+		var ok bool
+		b, ok = p.privateBlock(pos)
+		if !ok {
+			p.AbortBreaking()
+			p.resendBreakingBlock(pos, false)
+			return
+		}
 		p.ShowParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
 	} else {
 		b = p.tx.Block(pos)

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2085,16 +2085,16 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 		p.ViewPublicBlock(pos)
 	} else {
 		p.tx.SetBlock(pos, nil, nil)
+	}
 
-		if breakable, ok := b.(block.Breakable); ok {
-			info := breakable.BreakInfo()
-			if info.BreakHandler != nil {
-				info.BreakHandler(pos, p.tx, p)
-			}
+	if breakable, ok := b.(block.Breakable); ok {
+		info := breakable.BreakInfo()
+		if info.BreakHandler != nil {
+			info.BreakHandler(pos, p.tx, p)
 		}
 	}
-	p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 
+	p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 	for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
 		p.tx.AddEntity(orb)
 	}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1922,7 +1922,14 @@ func (p *Player) FinishBreaking() {
 		return
 	}
 	pos := p.breakingPos
+	private := p.breakingPrivate
 	p.AbortBreaking()
+	if private {
+		if b, ok := p.privateBlock(pos); ok {
+			p.breakBlock(pos, b, true)
+			return
+		}
+	}
 	p.BreakBlock(pos)
 }
 
@@ -2069,7 +2076,12 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 // BreakBlock makes the player break a block in the world at a position passed. If the player is unable to
 // reach the block passed, the method returns immediately.
 func (p *Player) BreakBlock(pos cube.Pos) {
-	b, private := p.breakingBlock(pos)
+	p.breakBlock(pos, p.tx.Block(pos), false)
+}
+
+// breakBlock makes the player break the block passed at the position passed. Private blocks are removed
+// from the player's view layer instead of the world.
+func (p *Player) breakBlock(pos cube.Pos, b world.Block, private bool) {
 	if _, air := b.(block.Air); air {
 		// Don't do anything if the position broken is already air.
 		return

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1943,6 +1943,8 @@ func (p *Player) FinishBreaking() {
 	if private {
 		if b, ok := p.privateBlock(pos); ok {
 			p.breakBlock(pos, b, true)
+		} else {
+			p.resendBreakingBlock(pos, false)
 		}
 		return
 	}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -98,6 +98,8 @@ type playerData struct {
 	breaking          bool
 	breakingPos       cube.Pos
 	breakingFace      cube.Face
+	breakingPrivate   bool
+	breakingPosValid  bool
 	lastBreakDuration time.Duration
 
 	breakCounter uint32
@@ -1838,8 +1840,7 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 // player might be breaking before this method is called.
 func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	p.AbortBreaking()
-	b := p.breakingBlock(pos)
-	_, private := p.privateBlock(pos)
+	b, private := p.breakingBlock(pos)
 	if _, air := b.(block.Air); air || !p.canReach(pos.Vec3Centre()) {
 		// The block was either out of range or air, so it can't be broken by the player.
 		return
@@ -1864,7 +1865,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	}
 	// Note: We intentionally store this regardless of whether the breaking proceeds, so that we
 	// can resend the block to the client when it tries to break the block regardless.
-	p.breakingPos = pos
+	p.breakingPos, p.breakingPrivate, p.breakingPosValid = pos, private, true
 
 	ctx := event.C(p)
 	if p.Handler().HandleStartBreak(ctx, pos); ctx.Cancelled() {
@@ -1874,7 +1875,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 		punchable.Punch(pos, face, p.tx, p)
 	}
 
-	p.breaking, p.breakingFace = true, face
+	p.breaking, p.breakingFace, p.breakingPrivate = true, face, private
 	p.SwingArm()
 
 	if p.GameMode().CreativeInventory() {
@@ -1914,11 +1915,15 @@ func (p *Player) breakTime(b world.Block) time.Duration {
 // FinishBreaking will stop the animation and break the block.
 func (p *Player) FinishBreaking() {
 	if !p.breaking {
-		p.resendNearbyBlock(p.breakingPos)
+		if p.breakingPosValid {
+			p.resendBreakingBlock(p.breakingPos, p.breakingPrivate)
+			p.breakingPosValid = false
+		}
 		return
 	}
+	pos := p.breakingPos
 	p.AbortBreaking()
-	p.BreakBlock(p.breakingPos)
+	p.BreakBlock(pos)
 }
 
 // AbortBreaking makes the player stop breaking the block it is currently breaking, or returns immediately
@@ -1926,10 +1931,11 @@ func (p *Player) FinishBreaking() {
 // Unlike FinishBreaking, AbortBreaking does not stop the animation.
 func (p *Player) AbortBreaking() {
 	if !p.breaking {
+		p.breakingPosValid = false
 		return
 	}
-	_, private := p.privateBlock(p.breakingPos)
-	p.breaking, p.breakCounter = false, 0
+	private := p.breakingPrivate
+	p.breaking, p.breakingPrivate, p.breakingPosValid, p.breakCounter = false, false, false, 0
 	p.viewBreakingBlockAction(p.breakingPos, private, block.StopCrackAction{})
 }
 
@@ -1941,10 +1947,13 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 		return
 	}
 	pos := p.breakingPos
-	b := p.breakingBlock(pos)
-	_, private := p.privateBlock(pos)
+	private := p.breakingPrivate
+	b := p.tx.Block(pos)
 	if private {
-		p.s.ViewParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
+		b, _ = p.breakingBlock(pos)
+	}
+	if private {
+		p.ShowParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
 	} else {
 		p.tx.AddParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
 	}
@@ -1955,7 +1964,7 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 		// We send this sound only every so often. Vanilla doesn't send it every tick while breaking
 		// either. Every 5 ticks seems accurate.
 		if private {
-			p.s.ViewSound(pos.Vec3(), sound.BlockBreaking{Block: b})
+			p.session().ViewSound(pos.Vec3(), sound.BlockBreaking{Block: b})
 		} else {
 			p.tx.PlaySound(pos.Vec3(), sound.BlockBreaking{Block: b})
 		}
@@ -1970,7 +1979,7 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 // block, or to all viewers if it is a public world block.
 func (p *Player) viewBreakingBlockAction(pos cube.Pos, private bool, a world.BlockAction) {
 	if private {
-		p.s.ViewBlockAction(pos, a)
+		p.session().ViewBlockAction(pos, a)
 		return
 	}
 	for _, viewer := range p.viewers() {
@@ -1979,11 +1988,11 @@ func (p *Player) viewBreakingBlockAction(pos cube.Pos, private bool, a world.Blo
 }
 
 // breakingBlock returns the block that should be used for the player's breaking progress.
-func (p *Player) breakingBlock(pos cube.Pos) world.Block {
+func (p *Player) breakingBlock(pos cube.Pos) (world.Block, bool) {
 	if b, ok := p.privateBlock(pos); ok {
-		return b
+		return b, true
 	}
-	return p.tx.Block(pos)
+	return p.tx.Block(pos), false
 }
 
 // PlaceBlock makes the player place the block passed at the position passed, granted it is within the range
@@ -2061,22 +2070,20 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 // BreakBlock makes the player break a block in the world at a position passed. If the player is unable to
 // reach the block passed, the method returns immediately.
 func (p *Player) BreakBlock(pos cube.Pos) {
-	b := p.tx.Block(pos)
-
-	privateBlock, private := p.privateBlock(pos)
-	if private {
-		b = privateBlock
-	}
+	b, private := p.breakingBlock(pos)
 	if _, air := b.(block.Air); air {
 		// Don't do anything if the position broken is already air.
 		return
 	}
+	resendBrokenBlock := func() {
+		p.resendBreakingBlock(pos, private)
+	}
 	if !p.canReach(pos.Vec3Centre()) || !p.GameMode().AllowsEditing() {
-		p.resendNearbyBlocks(pos)
+		resendBrokenBlock()
 		return
 	}
 	if _, breakable := b.(block.Breakable); !breakable && !p.GameMode().CreativeInventory() {
-		p.resendNearbyBlocks(pos)
+		resendBrokenBlock()
 		return
 	}
 	held, _ := p.HeldItems()
@@ -2094,7 +2101,7 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 
 	ctx := event.C(p)
 	if p.Handler().HandleBlockBreak(ctx, pos, &drops, &xp); ctx.Cancelled() {
-		p.resendNearbyBlocks(pos)
+		resendBrokenBlock()
 		return
 	}
 	held, left := p.HeldItems()
@@ -2102,7 +2109,7 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	p.SwingArm()
 	if private {
 		p.ViewPublicBlock(pos)
-		p.s.ViewParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
+		p.ShowParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 		return
 	} else {
 		p.tx.SetBlock(pos, nil, nil)
@@ -2157,6 +2164,15 @@ func (p *Player) privateBlock(pos cube.Pos) (world.Block, bool) {
 	return p.ViewLayer().Block(pos)
 }
 
+// resendBreakingBlock resends the block being broken without overwriting private view-layer overrides.
+func (p *Player) resendBreakingBlock(pos cube.Pos, private bool) {
+	if private {
+		p.session().ViewLayerBlockChanged(pos)
+		return
+	}
+	p.resendNearbyBlocks(pos)
+}
+
 // PickBlock makes the player pick a block in the world at a position passed. If the player is unable to
 // pick the block, the method returns immediately.
 func (p *Player) PickBlock(pos cube.Pos) {
@@ -2164,7 +2180,7 @@ func (p *Player) PickBlock(pos cube.Pos) {
 		return
 	}
 
-	b := p.breakingBlock(pos)
+	b, _ := p.breakingBlock(pos)
 
 	var pickedItem item.Stack
 	if pi, ok := b.(block.Pickable); ok {

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1922,14 +1922,7 @@ func (p *Player) FinishBreaking() {
 		return
 	}
 	pos := p.breakingPos
-	private := p.breakingPrivate
 	p.AbortBreaking()
-	if private {
-		if b, ok := p.privateBlock(pos); ok {
-			p.breakBlock(pos, b, true)
-			return
-		}
-	}
 	p.BreakBlock(pos)
 }
 
@@ -1989,8 +1982,21 @@ func (p *Player) viewBreakingBlockAction(pos cube.Pos, private bool, a world.Blo
 		return
 	}
 	for _, viewer := range p.viewers() {
+		if viewerHasPrivateBlock(viewer, pos) {
+			continue
+		}
 		viewer.ViewBlockAction(pos, a)
 	}
+}
+
+// viewerHasPrivateBlock returns true if the viewer has a private block override at pos.
+func viewerHasPrivateBlock(viewer world.Viewer, pos cube.Pos) bool {
+	s, ok := viewer.(*session.Session)
+	if !ok || s.ViewLayer() == nil {
+		return false
+	}
+	_, ok = s.ViewLayer().Block(pos)
+	return ok
 }
 
 // breakingBlock returns the block that should be used for the player's breaking progress.
@@ -2073,10 +2079,12 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 	return obstructed, true
 }
 
-// BreakBlock makes the player break a block in the world at a position passed. If the player is unable to
-// reach the block passed, the method returns immediately.
+// BreakBlock makes the player break a block at a position passed. If the player has a private block
+// override at that position, it is removed instead of breaking the public world block. If the player is
+// unable to reach the block passed, the method returns immediately.
 func (p *Player) BreakBlock(pos cube.Pos) {
-	p.breakBlock(pos, p.tx.Block(pos), false)
+	b, private := p.breakingBlock(pos)
+	p.breakBlock(pos, b, private)
 }
 
 // breakBlock makes the player break the block passed at the position passed. Private blocks are removed

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1839,6 +1839,9 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	p.AbortBreaking()
 	if _, air := p.tx.Block(pos).(block.Air); air || !p.canReach(pos.Vec3Centre()) {
+		if air && p.viewLayerBlock(pos) {
+			p.resendNearbyBlocks(pos)
+		}
 		// The block was either out of range or air, so it can't be broken by the player.
 		return
 	}

--- a/server/session/chunk.go
+++ b/server/session/chunk.go
@@ -164,7 +164,9 @@ func (s *Session) applyViewLayerToChunk(pos world.ChunkPos, c *chunk.Chunk, bloc
 			blockEntities = maps.Clone(blockEntities)
 			cloned = true
 		}
-		c.SetBlock(uint8(blockPos[0]), int16(blockPos[1]), uint8(blockPos[2]), 0, s.br.BlockRuntimeID(b))
+		x, y, z := uint8(blockPos[0]), int16(blockPos[1]), uint8(blockPos[2])
+		c.SetBlock(x, y, z, 0, s.br.BlockRuntimeID(b))
+		c.SetBlock(x, y, z, 1, s.br.AirRuntimeID())
 		if _, ok := b.(world.NBTer); ok {
 			blockEntities[blockPos] = b
 		} else {

--- a/server/session/chunk.go
+++ b/server/session/chunk.go
@@ -150,6 +150,9 @@ func (s *Session) applyViewLayerToChunk(pos world.ChunkPos, c *chunk.Chunk, bloc
 		if (world.ChunkPos{int32(blockPos[0] >> 4), int32(blockPos[2] >> 4)}) != pos {
 			continue
 		}
+		if blockPos.OutOfBounds(c.Range()) {
+			continue
+		}
 		if !cloned {
 			c = c.Clone()
 			blockEntities = maps.Clone(blockEntities)

--- a/server/session/chunk.go
+++ b/server/session/chunk.go
@@ -33,25 +33,31 @@ func (s *Session) ViewSubChunks(centre world.SubChunkPos, offsets []protocol.Sub
 
 	entries := make([]protocol.SubChunkEntry, 0, len(offsets))
 	transaction := make(map[uint64]struct{})
+	viewedChunks := make(map[world.ChunkPos]struct {
+		chunk         *chunk.Chunk
+		blockEntities map[cube.Pos]world.Block
+	})
 	for _, offset := range offsets {
 		ind := int16(centre.Y()) + int16(offset[1]) - int16(r[0])>>4
 		if ind < 0 || ind > int16(r.Height()>>4) {
 			entries = append(entries, protocol.SubChunkEntry{Result: protocol.SubChunkResultIndexOutOfBounds, Offset: offset})
 			continue
 		}
-		col, ok := s.chunkLoader.Chunk(world.ChunkPos{
+		chunkPos := world.ChunkPos{
 			centre.X() + int32(offset[0]),
 			centre.Z() + int32(offset[2]),
-		})
+		}
+		col, ok := s.chunkLoader.Chunk(chunkPos)
 		if !ok {
 			entries = append(entries, protocol.SubChunkEntry{Result: protocol.SubChunkResultChunkNotFound, Offset: offset})
 			continue
 		}
-		ch, blockEntities := s.applyViewLayerToChunk(world.ChunkPos{
-			centre.X() + int32(offset[0]),
-			centre.Z() + int32(offset[2]),
-		}, col.Chunk, col.BlockEntities)
-		entries = append(entries, s.subChunkEntry(offset, ind, ch, blockEntities, transaction))
+		viewed, ok := viewedChunks[chunkPos]
+		if !ok {
+			viewed.chunk, viewed.blockEntities = s.applyViewLayerToChunk(chunkPos, col.Chunk, col.BlockEntities)
+			viewedChunks[chunkPos] = viewed
+		}
+		entries = append(entries, s.subChunkEntry(offset, ind, viewed.chunk, viewed.blockEntities, transaction))
 	}
 	if s.conn.ClientCacheEnabled() && len(transaction) > 0 {
 		s.blobMu.Lock()

--- a/server/session/chunk.go
+++ b/server/session/chunk.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bytes"
+	"maps"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/df-mc/dragonfly/server/block/cube"
@@ -18,6 +19,7 @@ const subChunkRequests = true
 
 // ViewChunk ...
 func (s *Session) ViewChunk(pos world.ChunkPos, dim world.Dimension, blockEntities map[cube.Pos]world.Block, c *chunk.Chunk) {
+	c, blockEntities = s.applyViewLayerToChunk(pos, c, blockEntities)
 	if !s.conn.ClientCacheEnabled() {
 		s.sendNetworkChunk(pos, dim, c, blockEntities)
 		return
@@ -45,7 +47,11 @@ func (s *Session) ViewSubChunks(centre world.SubChunkPos, offsets []protocol.Sub
 			entries = append(entries, protocol.SubChunkEntry{Result: protocol.SubChunkResultChunkNotFound, Offset: offset})
 			continue
 		}
-		entries = append(entries, s.subChunkEntry(offset, ind, col, transaction))
+		ch, blockEntities := s.applyViewLayerToChunk(world.ChunkPos{
+			centre.X() + int32(offset[0]),
+			centre.Z() + int32(offset[2]),
+		}, col.Chunk, col.BlockEntities)
+		entries = append(entries, s.subChunkEntry(offset, ind, ch, blockEntities, transaction))
 	}
 	if s.conn.ClientCacheEnabled() && len(transaction) > 0 {
 		s.blobMu.Lock()
@@ -61,21 +67,21 @@ func (s *Session) ViewSubChunks(centre world.SubChunkPos, offsets []protocol.Sub
 	})
 }
 
-func (s *Session) subChunkEntry(offset protocol.SubChunkOffset, ind int16, col *world.Column, transaction map[uint64]struct{}) protocol.SubChunkEntry {
-	chunkMap := col.HeightMap()
+func (s *Session) subChunkEntry(offset protocol.SubChunkOffset, ind int16, c *chunk.Chunk, blockEntities map[cube.Pos]world.Block, transaction map[uint64]struct{}) protocol.SubChunkEntry {
+	chunkMap := c.HeightMap()
 	subMapType, subMap := byte(protocol.HeightMapDataHasData), make([]int8, 256)
 	higher, lower := true, true
 	for x := uint8(0); x < 16; x++ {
 		for z := uint8(0); z < 16; z++ {
 			y, i := chunkMap.At(x, z), (uint16(z)<<4)|uint16(x)
-			otherInd := col.SubIndex(y)
+			otherInd := c.SubIndex(y)
 			switch {
 			case otherInd > ind:
 				subMap[i], lower = 16, false
 			case otherInd < ind:
 				subMap[i], higher = -1, false
 			default:
-				subMap[i], lower, higher = int8(y-col.SubY(otherInd)), false, false
+				subMap[i], lower, higher = int8(y-c.SubY(otherInd)), false, false
 			}
 		}
 	}
@@ -85,7 +91,7 @@ func (s *Session) subChunkEntry(offset protocol.SubChunkOffset, ind int16, col *
 		subMapType, subMap = protocol.HeightMapDataTooLow, nil
 	}
 
-	sub := col.Sub()[ind]
+	sub := c.Sub()[ind]
 	if sub.Empty() {
 		return protocol.SubChunkEntry{
 			Result:              protocol.SubChunkResultSuccessAllAir,
@@ -97,12 +103,12 @@ func (s *Session) subChunkEntry(offset protocol.SubChunkOffset, ind int16, col *
 		}
 	}
 
-	serialisedSubChunk := chunk.EncodeSubChunk(col.Chunk, chunk.NetworkEncoding, int(ind))
+	serialisedSubChunk := chunk.EncodeSubChunk(c, chunk.NetworkEncoding, int(ind))
 
 	blockEntityBuf := bytes.NewBuffer(nil)
 	enc := nbt.NewEncoderWithEncoding(blockEntityBuf, nbt.NetworkLittleEndian)
-	for pos, b := range col.BlockEntities {
-		if n, ok := b.(world.NBTer); ok && col.SubIndex(int16(pos.Y())) == ind {
+	for pos, b := range blockEntities {
+		if n, ok := b.(world.NBTer); ok && c.SubIndex(int16(pos.Y())) == ind {
 			d := n.EncodeNBT()
 			d["x"], d["y"], d["z"] = int32(pos[0]), int32(pos[1]), int32(pos[2])
 			_ = enc.Encode(d)
@@ -127,6 +133,36 @@ func (s *Session) subChunkEntry(offset protocol.SubChunkOffset, ind int16, col *
 		}
 	}
 	return entry
+}
+
+// applyViewLayerToChunk returns a chunk and block entity map with this session's view-layer block overrides applied.
+func (s *Session) applyViewLayerToChunk(pos world.ChunkPos, c *chunk.Chunk, blockEntities map[cube.Pos]world.Block) (*chunk.Chunk, map[cube.Pos]world.Block) {
+	if s.viewLayer == nil {
+		return c, blockEntities
+	}
+	overrides := s.viewLayer.Blocks()
+	if len(overrides) == 0 {
+		return c, blockEntities
+	}
+
+	var cloned bool
+	for blockPos, b := range overrides {
+		if (world.ChunkPos{int32(blockPos[0] >> 4), int32(blockPos[2] >> 4)}) != pos {
+			continue
+		}
+		if !cloned {
+			c = c.Clone()
+			blockEntities = maps.Clone(blockEntities)
+			cloned = true
+		}
+		c.SetBlock(uint8(blockPos[0]), int16(blockPos[1]), uint8(blockPos[2]), 0, s.br.BlockRuntimeID(b))
+		if _, ok := b.(world.NBTer); ok {
+			blockEntities[blockPos] = b
+		} else {
+			delete(blockEntities, blockPos)
+		}
+	}
+	return c, blockEntities
 }
 
 // dimensionID returns the dimension ID of the world that the session is in.

--- a/server/session/chunk.go
+++ b/server/session/chunk.go
@@ -146,16 +146,13 @@ func (s *Session) applyViewLayerToChunk(pos world.ChunkPos, c *chunk.Chunk, bloc
 	if s.viewLayer == nil {
 		return c, blockEntities
 	}
-	overrides := s.viewLayer.Blocks()
+	overrides := s.viewLayer.ChunkBlocks(pos)
 	if len(overrides) == 0 {
 		return c, blockEntities
 	}
 
 	var cloned bool
 	for blockPos, b := range overrides {
-		if (world.ChunkPos{int32(blockPos[0] >> 4), int32(blockPos[2] >> 4)}) != pos {
-			continue
-		}
 		if blockPos.OutOfBounds(c.Range()) {
 			continue
 		}

--- a/server/session/controllable.go
+++ b/server/session/controllable.go
@@ -57,6 +57,7 @@ type Controllable interface {
 	UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec3)
 	UseItemOnEntity(e world.Entity) bool
 	BreakBlock(pos cube.Pos)
+	BreakViewedBlock(pos cube.Pos)
 	PickBlock(pos cube.Pos)
 	AttackEntity(e world.Entity) bool
 	Drop(s item.Stack) (n int)
@@ -124,15 +125,4 @@ type Controllable interface {
 	SetSkin(skin.Skin)
 
 	UpdateDiagnostics(Diagnostics)
-}
-
-// breakViewedBlock breaks the block currently shown to the controllable when supported. This preserves
-// session-driven client semantics for players with private view-layer block overrides while keeping BreakBlock
-// as the public-world block break API for generic Controllable implementations.
-func breakViewedBlock(c Controllable, pos cube.Pos) {
-	if breaker, ok := c.(interface{ BreakViewedBlock(cube.Pos) }); ok {
-		breaker.BreakViewedBlock(pos)
-		return
-	}
-	c.BreakBlock(pos)
 }

--- a/server/session/controllable.go
+++ b/server/session/controllable.go
@@ -125,3 +125,14 @@ type Controllable interface {
 
 	UpdateDiagnostics(Diagnostics)
 }
+
+// breakViewedBlock breaks the block currently shown to the controllable when supported. This preserves
+// session-driven client semantics for players with private view-layer block overrides while keeping BreakBlock
+// as the public-world block break API for generic Controllable implementations.
+func breakViewedBlock(c Controllable, pos cube.Pos) {
+	if breaker, ok := c.(interface{ BreakViewedBlock(cube.Pos) }); ok {
+		breaker.BreakViewedBlock(pos)
+		return
+	}
+	c.BreakBlock(pos)
+}

--- a/server/session/handler_inventory_transaction.go
+++ b/server/session/handler_inventory_transaction.go
@@ -187,7 +187,7 @@ func (h *InventoryTransactionHandler) handleUseItemTransaction(data *protocol.Us
 
 	switch data.ActionType {
 	case protocol.UseItemActionBreakBlock:
-		c.BreakBlock(pos)
+		breakViewedBlock(c, pos)
 	case protocol.UseItemActionClickBlock:
 		c.UseItemOnBlock(pos, cube.Face(data.BlockFace), vec32To64(data.ClickedPosition))
 	case protocol.UseItemActionClickAir:

--- a/server/session/handler_inventory_transaction.go
+++ b/server/session/handler_inventory_transaction.go
@@ -187,7 +187,7 @@ func (h *InventoryTransactionHandler) handleUseItemTransaction(data *protocol.Us
 
 	switch data.ActionType {
 	case protocol.UseItemActionBreakBlock:
-		breakViewedBlock(c, pos)
+		c.BreakViewedBlock(pos)
 	case protocol.UseItemActionClickBlock:
 		c.UseItemOnBlock(pos, cube.Face(data.BlockFace), vec32To64(data.ClickedPosition))
 	case protocol.UseItemActionClickAir:

--- a/server/session/handler_player_auth_input.go
+++ b/server/session/handler_player_auth_input.go
@@ -164,7 +164,7 @@ func (h PlayerAuthInputHandler) handleUseItemData(data protocol.UseItemTransacti
 	// Seems like this is only used for breaking blocks at the moment.
 	switch data.ActionType {
 	case protocol.UseItemActionBreakBlock:
-		c.BreakBlock(pos)
+		breakViewedBlock(c, pos)
 	default:
 		return fmt.Errorf("unhandled UseItem ActionType for PlayerAuthInput packet %v", data.ActionType)
 	}

--- a/server/session/handler_player_auth_input.go
+++ b/server/session/handler_player_auth_input.go
@@ -164,7 +164,7 @@ func (h PlayerAuthInputHandler) handleUseItemData(data protocol.UseItemTransacti
 	// Seems like this is only used for breaking blocks at the moment.
 	switch data.ActionType {
 	case protocol.UseItemActionBreakBlock:
-		breakViewedBlock(c, pos)
+		c.BreakViewedBlock(pos)
 	default:
 		return fmt.Errorf("unhandled UseItem ActionType for PlayerAuthInput packet %v", data.ActionType)
 	}

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -178,6 +178,11 @@ func (conf Config) New(conn Conn) *Session {
 	}
 	conf.Log = conf.Log.With("name", conn.IdentityData().DisplayName, "uuid", conn.IdentityData().Identity, "raddr", conn.RemoteAddr().String())
 
+	br := conf.BlockRegistry
+	if br == nil {
+		br = world.DefaultBlockRegistry
+	}
+
 	s := &Session{}
 	*s = Session{
 		openChunkTransactions:  make([]map[uint64]struct{}, 0, 8),
@@ -200,8 +205,9 @@ func (conf Config) New(conn Conn) *Session {
 		hiddenHud:              make(map[hud.Element]struct{}),
 		debugShapes:            make(map[int]debug.Shape),
 		debugShapeUpdates:      make([]debugShapeUpdate, 0, 256),
+		br:                     br,
 	}
-	s.viewLayer = world.NewViewLayer(s)
+	s.viewLayer = world.NewViewLayerWithBlockRegistry(s, br)
 	s.openedWindow.Store(inventory.New(1, nil))
 	s.openedPos.Store(&cube.Pos{})
 
@@ -209,12 +215,6 @@ func (conf Config) New(conn Conn) *Session {
 	var scoreboardLines []string
 	s.currentScoreboard.Store(&scoreboardName)
 	s.currentLines.Store(&scoreboardLines)
-
-	if conf.BlockRegistry == nil {
-		s.br = world.DefaultBlockRegistry
-	} else {
-		s.br = conf.BlockRegistry
-	}
 
 	s.registerHandlers()
 	s.sendBiomes()

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -207,7 +207,7 @@ func (conf Config) New(conn Conn) *Session {
 		debugShapeUpdates:      make([]debugShapeUpdate, 0, 256),
 		br:                     br,
 	}
-	s.viewLayer = world.NewViewLayerWithBlockRegistry(s, br)
+	s.viewLayer = world.NewViewLayer(s)
 	s.openedWindow.Store(inventory.New(1, nil))
 	s.openedPos.Store(&cube.Pos{})
 

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -178,11 +178,6 @@ func (conf Config) New(conn Conn) *Session {
 	}
 	conf.Log = conf.Log.With("name", conn.IdentityData().DisplayName, "uuid", conn.IdentityData().Identity, "raddr", conn.RemoteAddr().String())
 
-	br := conf.BlockRegistry
-	if br == nil {
-		br = world.DefaultBlockRegistry
-	}
-
 	s := &Session{}
 	*s = Session{
 		openChunkTransactions:  make([]map[uint64]struct{}, 0, 8),
@@ -205,7 +200,6 @@ func (conf Config) New(conn Conn) *Session {
 		hiddenHud:              make(map[hud.Element]struct{}),
 		debugShapes:            make(map[int]debug.Shape),
 		debugShapeUpdates:      make([]debugShapeUpdate, 0, 256),
-		br:                     br,
 	}
 	s.viewLayer = world.NewViewLayer(s)
 	s.openedWindow.Store(inventory.New(1, nil))
@@ -215,6 +209,12 @@ func (conf Config) New(conn Conn) *Session {
 	var scoreboardLines []string
 	s.currentScoreboard.Store(&scoreboardName)
 	s.currentLines.Store(&scoreboardLines)
+
+	if conf.BlockRegistry == nil {
+		s.br = world.DefaultBlockRegistry
+	} else {
+		s.br = conf.BlockRegistry
+	}
 
 	s.registerHandlers()
 	s.sendBiomes()

--- a/server/session/view_layer.go
+++ b/server/session/view_layer.go
@@ -1,6 +1,9 @@
 package session
 
-import "github.com/df-mc/dragonfly/server/world"
+import (
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+)
 
 // ViewLayer returns the session's ViewLayer. The layer may be used to override how entities are viewed
 // by this session, such as with a different name tag or visibility state.
@@ -48,6 +51,22 @@ func (s *Session) ViewVisibility(entity world.Entity, level world.VisibilityLeve
 	s.viewLayer.ViewVisibility(entity, level)
 }
 
+// ViewBlock overwrites the public block at the position passed and immediately refreshes it for this session.
+func (s *Session) ViewBlock(pos cube.Pos, b world.Block) {
+	if s.viewLayer == nil {
+		return
+	}
+	s.viewLayer.ViewBlock(pos, b)
+}
+
+// ViewPublicBlock removes the block override at the position passed and immediately refreshes it for this session.
+func (s *Session) ViewPublicBlock(pos cube.Pos) {
+	if s.viewLayer == nil {
+		return
+	}
+	s.viewLayer.ViewPublicBlock(pos)
+}
+
 // RemoveViewLayer removes all overrides for the entity and immediately refreshes it for this session.
 func (s *Session) RemoveViewLayer(entity world.Entity) {
 	if s.viewLayer == nil {
@@ -64,10 +83,34 @@ func (s *Session) ViewLayerEntityChanged(e world.Entity) {
 	s.ViewEntityState(e)
 }
 
+// ViewLayerBlockChanged refreshes the block for this session if its chunk is currently visible.
+func (s *Session) ViewLayerBlockChanged(pos cube.Pos) {
+	if b, ok := s.viewLayer.Block(pos); ok {
+		s.viewBlockUpdate(pos, b, 0)
+		return
+	}
+	if b, ok := s.publicBlock(pos); ok {
+		s.viewBlockUpdate(pos, b, 0)
+	}
+}
+
 // viewingEntity checks if this session currently has a runtime ID assigned to the entity handle.
 func (s *Session) viewingEntity(handle *world.EntityHandle) bool {
 	s.entityMutex.RLock()
 	_, ok := s.entityRuntimeIDs[handle]
 	s.entityMutex.RUnlock()
 	return ok
+}
+
+// publicBlock returns the public block at pos from the loaded chunk for this session.
+func (s *Session) publicBlock(pos cube.Pos) (world.Block, bool) {
+	col, ok := s.chunkLoader.Chunk(world.ChunkPos{int32(pos[0] >> 4), int32(pos[2] >> 4)})
+	if !ok {
+		return nil, false
+	}
+	if b, ok := col.BlockEntities[pos]; ok {
+		return b, true
+	}
+	b, ok := s.br.BlockByRuntimeID(col.Block(uint8(pos[0]), int16(pos[1]), uint8(pos[2]), 0))
+	return b, ok
 }

--- a/server/session/view_layer.go
+++ b/server/session/view_layer.go
@@ -85,10 +85,7 @@ func (s *Session) ViewLayerEntityChanged(e world.Entity) {
 
 // ViewLayerBlockChanged refreshes a block override for this session if its chunk is currently visible.
 func (s *Session) ViewLayerBlockChanged(pos cube.Pos) {
-	if s.viewLayer == nil {
-		return
-	}
-	if !s.viewingBlock(pos) {
+	if s.viewLayer == nil || !s.viewingBlock(pos) {
 		return
 	}
 	if b, ok := s.viewLayer.Block(pos); ok {

--- a/server/session/view_layer.go
+++ b/server/session/view_layer.go
@@ -93,11 +93,25 @@ func (s *Session) ViewLayerBlockChanged(pos cube.Pos) {
 	}
 	if b, ok := s.viewLayer.Block(pos); ok {
 		s.viewBlockUpdate(pos, b, 0)
+		s.viewBlockUpdate(pos, s.br.Air(), 1)
 		return
 	}
 	if b, ok := s.publicBlock(pos); ok {
 		s.viewBlockUpdate(pos, b, 0)
+		s.viewBlockUpdate(pos, s.publicLiquid(pos), 1)
 	}
+}
+
+// publicLiquid returns the public liquid layer loaded for this session at pos, or air if no liquid is present.
+func (s *Session) publicLiquid(pos cube.Pos) world.Block {
+	if s.chunkLoader == nil {
+		return s.br.Air()
+	}
+	col, ok := s.chunkLoader.Chunk(world.ChunkPos{int32(pos[0] >> 4), int32(pos[2] >> 4)})
+	if !ok || pos.OutOfBounds(col.Range()) {
+		return s.br.Air()
+	}
+	return s.br.BlockByRuntimeIDOrAir(col.Block(uint8(pos[0]), int16(pos[1]), uint8(pos[2]), 1))
 }
 
 // viewingEntity checks if this session currently has a runtime ID assigned to the entity handle.

--- a/server/session/view_layer.go
+++ b/server/session/view_layer.go
@@ -92,6 +92,7 @@ func (s *Session) ViewLayerBlockChanged(pos cube.Pos) {
 		return
 	}
 	if b, ok := s.viewLayer.Block(pos); ok {
+		s.advertisePrivateBlockSubChunk(pos)
 		s.viewBlockUpdate(pos, b, 0)
 		s.viewBlockUpdate(pos, s.br.Air(), 1)
 		return
@@ -100,6 +101,28 @@ func (s *Session) ViewLayerBlockChanged(pos cube.Pos) {
 		s.viewBlockUpdate(pos, b, 0)
 		s.viewBlockUpdate(pos, s.publicLiquid(pos), 1)
 	}
+}
+
+// advertisePrivateBlockSubChunk resends the chunk height advert if a private block override occupies a
+// sub-chunk the client may not have loaded from the public chunk state.
+func (s *Session) advertisePrivateBlockSubChunk(pos cube.Pos) {
+	if !subChunkRequests || s.chunkLoader == nil {
+		return
+	}
+	chunkPos := world.ChunkPos{int32(pos[0] >> 4), int32(pos[2] >> 4)}
+	col, ok := s.chunkLoader.Chunk(chunkPos)
+	if !ok || pos.OutOfBounds(col.Range()) {
+		return
+	}
+	if uint16(col.SubIndex(int16(pos[1]))) <= col.HighestFilledSubChunk() {
+		return
+	}
+	w := s.chunkLoader.World()
+	if w == nil {
+		return
+	}
+	c, blockEntities := s.applyViewLayerToChunk(chunkPos, col.Chunk, col.BlockEntities)
+	s.sendNetworkChunk(chunkPos, w.Dimension(), c, blockEntities)
 }
 
 // publicLiquid returns the public liquid layer loaded for this session at pos, or air if no liquid is present.

--- a/server/session/view_layer.go
+++ b/server/session/view_layer.go
@@ -89,7 +89,7 @@ func (s *Session) ViewLayerBlockChanged(pos cube.Pos) {
 		return
 	}
 	if b, ok := s.viewLayer.Block(pos); ok {
-		s.advertisePrivateBlockSubChunk(pos)
+		s.broadcastPrivateBlockSubChunk(pos)
 		s.viewBlockUpdate(pos, b, 0)
 		s.viewBlockUpdate(pos, s.br.Air(), 1)
 		return
@@ -100,9 +100,9 @@ func (s *Session) ViewLayerBlockChanged(pos cube.Pos) {
 	}
 }
 
-// advertisePrivateBlockSubChunk resends the chunk height advert if a private block override occupies a
+// broadcastPrivateBlockSubChunk resends the chunk height advert if a private block override occupies a
 // sub-chunk the client may not have loaded from the public chunk state.
-func (s *Session) advertisePrivateBlockSubChunk(pos cube.Pos) {
+func (s *Session) broadcastPrivateBlockSubChunk(pos cube.Pos) {
 	if !subChunkRequests || s.chunkLoader == nil {
 		return
 	}

--- a/server/session/view_layer.go
+++ b/server/session/view_layer.go
@@ -59,7 +59,7 @@ func (s *Session) ViewBlock(pos cube.Pos, b world.Block) {
 	s.viewLayer.ViewBlock(pos, b)
 }
 
-// ViewPublicBlock removes the block override at the position passed.
+// ViewPublicBlock removes the block override at the position passed and immediately refreshes it for this session.
 func (s *Session) ViewPublicBlock(pos cube.Pos) {
 	if s.viewLayer == nil {
 		return
@@ -85,10 +85,17 @@ func (s *Session) ViewLayerEntityChanged(e world.Entity) {
 
 // ViewLayerBlockChanged refreshes a block override for this session if its chunk is currently visible.
 func (s *Session) ViewLayerBlockChanged(pos cube.Pos) {
+	if s.viewLayer == nil {
+		return
+	}
 	if !s.viewingBlock(pos) {
 		return
 	}
 	if b, ok := s.viewLayer.Block(pos); ok {
+		s.viewBlockUpdate(pos, b, 0)
+		return
+	}
+	if b, ok := s.publicBlock(pos); ok {
 		s.viewBlockUpdate(pos, b, 0)
 	}
 }
@@ -111,4 +118,19 @@ func (s *Session) viewingBlock(pos cube.Pos) bool {
 		return false
 	}
 	return !pos.OutOfBounds(col.Range())
+}
+
+// publicBlock returns the public block loaded for this session at pos.
+func (s *Session) publicBlock(pos cube.Pos) (world.Block, bool) {
+	if s.chunkLoader == nil {
+		return nil, false
+	}
+	col, ok := s.chunkLoader.Chunk(world.ChunkPos{int32(pos[0] >> 4), int32(pos[2] >> 4)})
+	if !ok || pos.OutOfBounds(col.Range()) {
+		return nil, false
+	}
+	if b, ok := col.BlockEntities[pos]; ok {
+		return b, true
+	}
+	return s.br.BlockByRuntimeID(col.Block(uint8(pos[0]), int16(pos[1]), uint8(pos[2]), 0))
 }

--- a/server/session/view_layer.go
+++ b/server/session/view_layer.go
@@ -59,7 +59,7 @@ func (s *Session) ViewBlock(pos cube.Pos, b world.Block) {
 	s.viewLayer.ViewBlock(pos, b)
 }
 
-// ViewPublicBlock removes the block override at the position passed and immediately refreshes it for this session.
+// ViewPublicBlock removes the block override at the position passed.
 func (s *Session) ViewPublicBlock(pos cube.Pos) {
 	if s.viewLayer == nil {
 		return
@@ -83,13 +83,12 @@ func (s *Session) ViewLayerEntityChanged(e world.Entity) {
 	s.ViewEntityState(e)
 }
 
-// ViewLayerBlockChanged refreshes the block for this session if its chunk is currently visible.
+// ViewLayerBlockChanged refreshes a block override for this session if its chunk is currently visible.
 func (s *Session) ViewLayerBlockChanged(pos cube.Pos) {
-	if b, ok := s.viewLayer.Block(pos); ok {
-		s.viewBlockUpdate(pos, b, 0)
+	if !s.viewingBlock(pos) {
 		return
 	}
-	if b, ok := s.publicBlock(pos); ok {
+	if b, ok := s.viewLayer.Block(pos); ok {
 		s.viewBlockUpdate(pos, b, 0)
 	}
 }
@@ -102,15 +101,14 @@ func (s *Session) viewingEntity(handle *world.EntityHandle) bool {
 	return ok
 }
 
-// publicBlock returns the public block at pos from the loaded chunk for this session.
-func (s *Session) publicBlock(pos cube.Pos) (world.Block, bool) {
+// viewingBlock returns true if the block position is loaded for this session.
+func (s *Session) viewingBlock(pos cube.Pos) bool {
+	if s.chunkLoader == nil {
+		return false
+	}
 	col, ok := s.chunkLoader.Chunk(world.ChunkPos{int32(pos[0] >> 4), int32(pos[2] >> 4)})
 	if !ok {
-		return nil, false
+		return false
 	}
-	if b, ok := col.BlockEntities[pos]; ok {
-		return b, true
-	}
-	b, ok := s.br.BlockByRuntimeID(col.Block(uint8(pos[0]), int16(pos[1]), uint8(pos[2]), 0))
-	return b, ok
+	return !pos.OutOfBounds(col.Range())
 }

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -1258,6 +1258,21 @@ func (s *Session) ViewSlotChange(slot int, newItem item.Stack) {
 
 // ViewBlockAction ...
 func (s *Session) ViewBlockAction(pos cube.Pos, a world.BlockAction) {
+	if s.viewLayer != nil {
+		if _, ok := s.viewLayer.Block(pos); ok {
+			return
+		}
+	}
+	s.viewBlockAction(pos, a)
+}
+
+// ViewPrivateBlockAction views an action performed by a private view-layer block.
+func (s *Session) ViewPrivateBlockAction(pos cube.Pos, a world.BlockAction) {
+	s.viewBlockAction(pos, a)
+}
+
+// viewBlockAction sends a block action without applying view-layer filters.
+func (s *Session) viewBlockAction(pos cube.Pos, a world.BlockAction) {
 	blockPos := protocol.BlockPos{int32(pos[0]), int32(pos[1]), int32(pos[2])}
 	switch t := a.(type) {
 	case block.OpenAction:

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -959,9 +959,13 @@ func (s *Session) ViewBrewingUpdate(prevBrewTime, brewTime time.Duration, prevFu
 
 // ViewBlockUpdate ...
 func (s *Session) ViewBlockUpdate(pos cube.Pos, b world.Block, layer int) {
-	if s.viewLayer != nil && layer == 0 {
+	if s.viewLayer != nil {
 		if viewed, ok := s.viewLayer.Block(pos); ok {
-			b = viewed
+			if layer == 0 {
+				b = viewed
+			} else {
+				b = s.br.Air()
+			}
 		}
 	}
 	s.viewBlockUpdate(pos, b, layer)

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -384,6 +384,7 @@ func (s *Session) ViewParticle(pos mgl64.Vec3, p world.Particle) {
 		s.writePacket(&packet.LevelEvent{
 			EventType: packet.LevelEventParticleCropGrowth,
 			Position:  vec64To32(pos),
+			EventData: int32(boolByte(pa.Area)),
 		})
 	case particle.BlockForceField:
 		s.writePacket(&packet.LevelEvent{

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -959,6 +959,16 @@ func (s *Session) ViewBrewingUpdate(prevBrewTime, brewTime time.Duration, prevFu
 
 // ViewBlockUpdate ...
 func (s *Session) ViewBlockUpdate(pos cube.Pos, b world.Block, layer int) {
+	if s.viewLayer != nil && layer == 0 {
+		if viewed, ok := s.viewLayer.Block(pos); ok {
+			b = viewed
+		}
+	}
+	s.viewBlockUpdate(pos, b, layer)
+}
+
+// viewBlockUpdate sends a block update to the session without applying view-layer overrides.
+func (s *Session) viewBlockUpdate(pos cube.Pos, b world.Block, layer int) {
 	blockPos := protocol.BlockPos{int32(pos[0]), int32(pos[1]), int32(pos[2])}
 	s.writePacket(&packet.UpdateBlock{
 		Position:          blockPos,

--- a/server/world/chunk/chunk.go
+++ b/server/world/chunk/chunk.go
@@ -49,6 +49,26 @@ func New(br BlockRegistry, r cube.Range) *Chunk {
 	}
 }
 
+// Clone returns an independent copy of the Chunk.
+func (chunk *Chunk) Clone() *Chunk {
+	clone := &Chunk{
+		r:                    chunk.r,
+		br:                   chunk.br,
+		air:                  chunk.air,
+		recalculateHeightMap: chunk.recalculateHeightMap,
+		heightMap:            slices.Clone(chunk.heightMap),
+		sub:                  make([]*SubChunk, len(chunk.sub)),
+		biomes:               make([]*PalettedStorage, len(chunk.biomes)),
+	}
+	for i, sub := range chunk.sub {
+		clone.sub[i] = sub.Clone()
+	}
+	for i, biomes := range chunk.biomes {
+		clone.biomes[i] = biomes.Clone()
+	}
+	return clone
+}
+
 // Equals returns if the chunk passed is equal to the current one
 func (chunk *Chunk) Equals(c *Chunk) bool {
 	if !chunk.recalculateHeightMap && !c.recalculateHeightMap && !slices.Equal(c.heightMap, chunk.heightMap) {

--- a/server/world/chunk/chunk.go
+++ b/server/world/chunk/chunk.go
@@ -49,6 +49,26 @@ func New(br BlockRegistry, r cube.Range) *Chunk {
 	}
 }
 
+// Clone returns an independent copy of the Chunk.
+func (chunk *Chunk) Clone() *Chunk {
+	clone := &Chunk{
+		r:                    chunk.r,
+		br:                   chunk.br,
+		air:                  chunk.air,
+		recalculateHeightMap: chunk.recalculateHeightMap,
+		heightMap:            append(HeightMap(nil), chunk.heightMap...),
+		sub:                  make([]*SubChunk, len(chunk.sub)),
+		biomes:               make([]*PalettedStorage, len(chunk.biomes)),
+	}
+	for i, sub := range chunk.sub {
+		clone.sub[i] = sub.Clone()
+	}
+	for i, biomes := range chunk.biomes {
+		clone.biomes[i] = biomes.Clone()
+	}
+	return clone
+}
+
 // Equals returns if the chunk passed is equal to the current one
 func (chunk *Chunk) Equals(c *Chunk) bool {
 	if !chunk.recalculateHeightMap && !c.recalculateHeightMap && !slices.Equal(c.heightMap, chunk.heightMap) {

--- a/server/world/chunk/palette.go
+++ b/server/world/chunk/palette.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"math"
+	"slices"
 )
 
 // paletteSize is the size of a palette. It indicates the amount of bits occupied per value stored.
@@ -21,6 +22,16 @@ type Palette struct {
 // newPalette returns a new Palette with size and a slice of added values.
 func newPalette(size paletteSize, values []uint32) *Palette {
 	return &Palette{size: size, values: values, last: math.MaxUint32}
+}
+
+// Clone returns an independent copy of the Palette.
+func (palette *Palette) Clone() *Palette {
+	return &Palette{
+		last:      palette.last,
+		lastIndex: palette.lastIndex,
+		size:      palette.size,
+		values:    slices.Clone(palette.values),
+	}
 }
 
 // Len returns the amount of unique values in the Palette.

--- a/server/world/chunk/palette.go
+++ b/server/world/chunk/palette.go
@@ -23,6 +23,11 @@ func newPalette(size paletteSize, values []uint32) *Palette {
 	return &Palette{size: size, values: values, last: math.MaxUint32}
 }
 
+// Clone returns an independent copy of the Palette.
+func (palette *Palette) Clone() *Palette {
+	return newPalette(palette.size, append([]uint32(nil), palette.values...))
+}
+
 // Len returns the amount of unique values in the Palette.
 func (palette *Palette) Len() int {
 	return len(palette.values)

--- a/server/world/chunk/paletted_storage.go
+++ b/server/world/chunk/paletted_storage.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"bytes"
+	"slices"
 	"unsafe"
 )
 
@@ -57,6 +58,11 @@ func newPalettedStorage(indices []uint32, palette *Palette) *PalettedStorage {
 // emptyStorage creates a PalettedStorage filled completely with a value v.
 func emptyStorage(v uint32) *PalettedStorage {
 	return newPalettedStorage([]uint32{}, newPalette(0, []uint32{v}))
+}
+
+// Clone returns an independent copy of the PalettedStorage.
+func (storage *PalettedStorage) Clone() *PalettedStorage {
+	return newPalettedStorage(slices.Clone(storage.indices), storage.palette.Clone())
 }
 
 // Palette returns the Palette of the PalettedStorage.
@@ -164,7 +170,7 @@ func (storage *PalettedStorage) resize(newPaletteSize paletteSize) {
 // relatively heavy task which should only happen right before the sub chunk holding this PalettedStorage is
 // saved to disk. compact also shrinks the palette size if possible.
 func (storage *PalettedStorage) compact() {
-	if storage.palette == nil || storage.palette.Len() == 0 {
+	if storage.palette.Len() == 0 {
 		return
 	}
 	if storage.palette.Len() == 1 {

--- a/server/world/chunk/paletted_storage.go
+++ b/server/world/chunk/paletted_storage.go
@@ -59,6 +59,11 @@ func emptyStorage(v uint32) *PalettedStorage {
 	return newPalettedStorage([]uint32{}, newPalette(0, []uint32{v}))
 }
 
+// Clone returns an independent copy of the PalettedStorage.
+func (storage *PalettedStorage) Clone() *PalettedStorage {
+	return newPalettedStorage(append([]uint32(nil), storage.indices...), storage.palette.Clone())
+}
+
 // Palette returns the Palette of the PalettedStorage.
 func (storage *PalettedStorage) Palette() *Palette {
 	return storage.palette

--- a/server/world/chunk/sub_chunk.go
+++ b/server/world/chunk/sub_chunk.go
@@ -1,5 +1,7 @@
 package chunk
 
+import "slices"
+
 // SubChunk is a cube of blocks located in a chunk. It has a size of 16x16x16 blocks and forms part of a stack
 // that forms a Chunk.
 type SubChunk struct {
@@ -27,6 +29,34 @@ func (sub *SubChunk) Equals(s *SubChunk) bool {
 // NewSubChunk creates a new sub chunk. All sub chunks should be created through this function.
 func NewSubChunk(air uint32) *SubChunk {
 	return &SubChunk{air: air}
+}
+
+// Clone returns an independent copy of the SubChunk.
+func (sub *SubChunk) Clone() *SubChunk {
+	clone := &SubChunk{
+		air:        sub.air,
+		storages:   make([]*PalettedStorage, len(sub.storages)),
+		blockLight: cloneLight(sub.blockLight),
+		skyLight:   cloneLight(sub.skyLight),
+	}
+	for i, storage := range sub.storages {
+		clone.storages[i] = storage.Clone()
+	}
+	return clone
+}
+
+func cloneLight(light []uint8) []uint8 {
+	if len(light) == 0 {
+		return slices.Clone(light)
+	}
+	switch &light[0] {
+	case noLightPtr:
+		return noLight
+	case fullLightPtr:
+		return fullLight
+	default:
+		return slices.Clone(light)
+	}
 }
 
 // Empty checks if the SubChunk is considered empty. This is the case if the SubChunk has 0 block storages or if it has

--- a/server/world/chunk/sub_chunk.go
+++ b/server/world/chunk/sub_chunk.go
@@ -29,6 +29,20 @@ func NewSubChunk(air uint32) *SubChunk {
 	return &SubChunk{air: air}
 }
 
+// Clone returns an independent copy of the SubChunk.
+func (sub *SubChunk) Clone() *SubChunk {
+	clone := &SubChunk{
+		air:        sub.air,
+		blockLight: append([]uint8(nil), sub.blockLight...),
+		skyLight:   append([]uint8(nil), sub.skyLight...),
+		storages:   make([]*PalettedStorage, len(sub.storages)),
+	}
+	for i, storage := range sub.storages {
+		clone.storages[i] = storage.Clone()
+	}
+	return clone
+}
+
 // Empty checks if the SubChunk is considered empty. This is the case if the SubChunk has 0 block storages or if it has
 // a single one that is completely filled with air.
 func (sub *SubChunk) Empty() bool {

--- a/server/world/particle/block.go
+++ b/server/world/particle/block.go
@@ -1,11 +1,12 @@
 package particle
 
 import (
+	"image/color"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/sound"
 	"github.com/go-gl/mathgl/mgl64"
-	"image/color"
 )
 
 // Flame is a particle shown around torches. It can have any colour specified with the Colour field.
@@ -49,7 +50,14 @@ type PunchBlock struct {
 type BlockForceField struct{ particle }
 
 // BoneMeal is a particle that shows up on bone meal usage.
-type BoneMeal struct{ particle }
+type BoneMeal struct {
+	particle
+
+	// Area specifies whether the particle effect should be for area. If false,
+	// a small burst is used for minor growth. If true, a large burst is used
+	// for significant growth.
+	Area bool
+}
 
 // Note is a particle that shows up on note block interactions.
 type Note struct {

--- a/server/world/view_layer.go
+++ b/server/world/view_layer.go
@@ -33,18 +33,18 @@ type viewLayerViewer interface {
 // ViewLayer holds overrides for how entities are viewed by a single viewer. It allows entities to be
 // viewed differently by different players, such as with a different name tag or visibility state.
 type ViewLayer struct {
-	mu       sync.RWMutex
-	entities map[*EntityHandle]layer
-	blocks   map[cube.Pos]Block
-	updater  ViewLayerUpdater
+	mu            sync.RWMutex
+	entities      map[*EntityHandle]layer
+	blocksByChunk map[ChunkPos]map[cube.Pos]Block
+	updater       ViewLayerUpdater
 }
 
 // NewViewLayer returns a new ViewLayer.
 func NewViewLayer(updater ViewLayerUpdater) *ViewLayer {
 	return &ViewLayer{
-		entities: map[*EntityHandle]layer{},
-		blocks:   map[cube.Pos]Block{},
-		updater:  updater,
+		entities:      map[*EntityHandle]layer{},
+		blocksByChunk: map[ChunkPos]map[cube.Pos]Block{},
+		updater:       updater,
 	}
 }
 
@@ -132,10 +132,17 @@ func (v *ViewLayer) Visibility(entity Entity) VisibilityLevel {
 // Passing nil removes the block override, causing the public block to be viewed again.
 func (v *ViewLayer) ViewBlock(pos cube.Pos, b Block) {
 	v.mu.Lock()
+	chunkPos := ChunkPos{int32(pos[0] >> 4), int32(pos[2] >> 4)}
 	if b == nil {
-		delete(v.blocks, pos)
+		delete(v.blocksByChunk[chunkPos], pos)
+		if len(v.blocksByChunk[chunkPos]) == 0 {
+			delete(v.blocksByChunk, chunkPos)
+		}
 	} else {
-		v.blocks[pos] = b
+		if v.blocksByChunk[chunkPos] == nil {
+			v.blocksByChunk[chunkPos] = map[cube.Pos]Block{}
+		}
+		v.blocksByChunk[chunkPos][pos] = b
 	}
 	v.mu.Unlock()
 
@@ -152,7 +159,7 @@ func (v *ViewLayer) Block(pos cube.Pos) (Block, bool) {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 
-	b, ok := v.blocks[pos]
+	b, ok := v.blocksByChunk[ChunkPos{int32(pos[0] >> 4), int32(pos[2] >> 4)}][pos]
 	return b, ok
 }
 
@@ -161,7 +168,23 @@ func (v *ViewLayer) Blocks() map[cube.Pos]Block {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 
-	return maps.Clone(v.blocks)
+	blocks := make(map[cube.Pos]Block)
+	for _, chunkBlocks := range v.blocksByChunk {
+		maps.Copy(blocks, chunkBlocks)
+	}
+	return blocks
+}
+
+// ChunkBlocks returns all block overrides in a chunk.
+func (v *ViewLayer) ChunkBlocks(pos ChunkPos) map[cube.Pos]Block {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	blocks := v.blocksByChunk[pos]
+	if len(blocks) == 0 {
+		return nil
+	}
+	return maps.Clone(blocks)
 }
 
 // Remove removes all overrides for the entity from the ViewLayer.
@@ -207,7 +230,7 @@ func (v *ViewLayer) Close() error {
 	defer v.mu.Unlock()
 
 	clear(v.entities)
-	clear(v.blocks)
+	clear(v.blocksByChunk)
 	return nil
 }
 

--- a/server/world/view_layer.go
+++ b/server/world/view_layer.go
@@ -19,6 +19,9 @@ type layer struct {
 type ViewLayerUpdater interface {
 	// ViewLayerEntityChanged handles an entity whose view-layer overrides changed.
 	ViewLayerEntityChanged(entity Entity)
+}
+
+type viewLayerBlockUpdater interface {
 	// ViewLayerBlockChanged handles a block whose view-layer override changed.
 	ViewLayerBlockChanged(pos cube.Pos)
 }
@@ -30,29 +33,18 @@ type viewLayerViewer interface {
 // ViewLayer holds overrides for how entities are viewed by a single viewer. It allows entities to be
 // viewed differently by different players, such as with a different name tag or visibility state.
 type ViewLayer struct {
-	mu            sync.RWMutex
-	entities      map[*EntityHandle]layer
-	blocks        map[cube.Pos]uint32
-	blockRegistry BlockRegistry
-	updater       ViewLayerUpdater
+	mu       sync.RWMutex
+	entities map[*EntityHandle]layer
+	blocks   map[cube.Pos]Block
+	updater  ViewLayerUpdater
 }
 
 // NewViewLayer returns a new ViewLayer.
 func NewViewLayer(updater ViewLayerUpdater) *ViewLayer {
-	return NewViewLayerWithBlockRegistry(updater, DefaultBlockRegistry)
-}
-
-// NewViewLayerWithBlockRegistry returns a new ViewLayer using the BlockRegistry passed for block runtime ID
-// conversions.
-func NewViewLayerWithBlockRegistry(updater ViewLayerUpdater, br BlockRegistry) *ViewLayer {
-	if br == nil {
-		br = DefaultBlockRegistry
-	}
 	return &ViewLayer{
-		entities:      map[*EntityHandle]layer{},
-		blocks:        map[cube.Pos]uint32{},
-		blockRegistry: br,
-		updater:       updater,
+		entities: map[*EntityHandle]layer{},
+		blocks:   map[cube.Pos]Block{},
+		updater:  updater,
 	}
 }
 
@@ -143,7 +135,7 @@ func (v *ViewLayer) ViewBlock(pos cube.Pos, b Block) {
 	if b == nil {
 		delete(v.blocks, pos)
 	} else {
-		v.blocks[pos] = v.blockRegistry.BlockRuntimeID(b)
+		v.blocks[pos] = b
 	}
 	v.mu.Unlock()
 
@@ -160,11 +152,7 @@ func (v *ViewLayer) Block(pos cube.Pos) (Block, bool) {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 
-	rid, ok := v.blocks[pos]
-	if !ok {
-		return nil, false
-	}
-	b, ok := v.blockRegistry.BlockByRuntimeID(rid)
+	b, ok := v.blocks[pos]
 	return b, ok
 }
 
@@ -173,13 +161,7 @@ func (v *ViewLayer) Blocks() map[cube.Pos]Block {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 
-	blocks := make(map[cube.Pos]Block, len(v.blocks))
-	for pos, rid := range v.blocks {
-		if b, ok := v.blockRegistry.BlockByRuntimeID(rid); ok {
-			blocks[pos] = b
-		}
-	}
-	return blocks
+	return maps.Clone(v.blocks)
 }
 
 // Remove removes all overrides for the entity from the ViewLayer.
@@ -241,7 +223,7 @@ func (v *ViewLayer) refresh(entity Entity) {
 }
 
 func (v *ViewLayer) refreshBlock(pos cube.Pos) {
-	if v.updater != nil {
-		v.updater.ViewLayerBlockChanged(pos)
+	if updater, ok := v.updater.(viewLayerBlockUpdater); ok {
+		updater.ViewLayerBlockChanged(pos)
 	}
 }

--- a/server/world/view_layer.go
+++ b/server/world/view_layer.go
@@ -128,8 +128,9 @@ func (v *ViewLayer) Visibility(entity Entity) VisibilityLevel {
 	return v.entities[entity.H()].visibility
 }
 
-// ViewBlock overwrites the public block at the position passed for this ViewLayer.
-// Passing nil removes the block override, causing the public block to be viewed again.
+// ViewBlock overwrites the public block at the position passed for this ViewLayer. Liquid or waterlogged
+// state at layer 1 is not represented for overrides. Passing nil removes the block override, causing the
+// public block to be viewed again.
 func (v *ViewLayer) ViewBlock(pos cube.Pos, b Block) {
 	v.mu.Lock()
 	chunkPos := ChunkPos{int32(pos[0] >> 4), int32(pos[2] >> 4)}

--- a/server/world/view_layer.go
+++ b/server/world/view_layer.go
@@ -4,6 +4,8 @@ import (
 	"maps"
 	"slices"
 	"sync"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
 )
 
 // layer stores the appearance overrides that a ViewLayer applies to an entity.
@@ -17,6 +19,8 @@ type layer struct {
 type ViewLayerUpdater interface {
 	// ViewLayerEntityChanged handles an entity whose view-layer overrides changed.
 	ViewLayerEntityChanged(entity Entity)
+	// ViewLayerBlockChanged handles a block whose view-layer override changed.
+	ViewLayerBlockChanged(pos cube.Pos)
 }
 
 type viewLayerViewer interface {
@@ -28,6 +32,7 @@ type viewLayerViewer interface {
 type ViewLayer struct {
 	mu       sync.RWMutex
 	entities map[*EntityHandle]layer
+	blocks   map[cube.Pos]Block
 	updater  ViewLayerUpdater
 }
 
@@ -35,6 +40,7 @@ type ViewLayer struct {
 func NewViewLayer(updater ViewLayerUpdater) *ViewLayer {
 	return &ViewLayer{
 		entities: map[*EntityHandle]layer{},
+		blocks:   map[cube.Pos]Block{},
 		updater:  updater,
 	}
 }
@@ -119,6 +125,42 @@ func (v *ViewLayer) Visibility(entity Entity) VisibilityLevel {
 	return v.entities[entity.H()].visibility
 }
 
+// ViewBlock overwrites the public block at the position passed for this ViewLayer.
+// Passing nil removes the block override, causing the public block to be viewed again.
+func (v *ViewLayer) ViewBlock(pos cube.Pos, b Block) {
+	v.mu.Lock()
+	if b == nil {
+		delete(v.blocks, pos)
+	} else {
+		v.blocks[pos] = b
+	}
+	v.mu.Unlock()
+
+	v.refreshBlock(pos)
+}
+
+// ViewPublicBlock removes the block override at the position passed, causing the public block to be viewed again.
+func (v *ViewLayer) ViewPublicBlock(pos cube.Pos) {
+	v.ViewBlock(pos, nil)
+}
+
+// Block returns the overwritten block at the position passed and whether an override was set.
+func (v *ViewLayer) Block(pos cube.Pos) (Block, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	b, ok := v.blocks[pos]
+	return b, ok
+}
+
+// Blocks returns all block overrides in the view layer.
+func (v *ViewLayer) Blocks() map[cube.Pos]Block {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	return maps.Clone(v.blocks)
+}
+
 // Remove removes all overrides for the entity from the ViewLayer.
 func (v *ViewLayer) Remove(entity Entity) {
 	if v.remove(entity) {
@@ -162,6 +204,7 @@ func (v *ViewLayer) Close() error {
 	defer v.mu.Unlock()
 
 	clear(v.entities)
+	clear(v.blocks)
 	return nil
 }
 
@@ -173,5 +216,11 @@ func (l layer) empty() bool {
 func (v *ViewLayer) refresh(entity Entity) {
 	if v.updater != nil {
 		v.updater.ViewLayerEntityChanged(entity)
+	}
+}
+
+func (v *ViewLayer) refreshBlock(pos cube.Pos) {
+	if v.updater != nil {
+		v.updater.ViewLayerBlockChanged(pos)
 	}
 }

--- a/server/world/view_layer.go
+++ b/server/world/view_layer.go
@@ -30,18 +30,29 @@ type viewLayerViewer interface {
 // ViewLayer holds overrides for how entities are viewed by a single viewer. It allows entities to be
 // viewed differently by different players, such as with a different name tag or visibility state.
 type ViewLayer struct {
-	mu       sync.RWMutex
-	entities map[*EntityHandle]layer
-	blocks   map[cube.Pos]Block
-	updater  ViewLayerUpdater
+	mu            sync.RWMutex
+	entities      map[*EntityHandle]layer
+	blocks        map[cube.Pos]uint32
+	blockRegistry BlockRegistry
+	updater       ViewLayerUpdater
 }
 
 // NewViewLayer returns a new ViewLayer.
 func NewViewLayer(updater ViewLayerUpdater) *ViewLayer {
+	return NewViewLayerWithBlockRegistry(updater, DefaultBlockRegistry)
+}
+
+// NewViewLayerWithBlockRegistry returns a new ViewLayer using the BlockRegistry passed for block runtime ID
+// conversions.
+func NewViewLayerWithBlockRegistry(updater ViewLayerUpdater, br BlockRegistry) *ViewLayer {
+	if br == nil {
+		br = DefaultBlockRegistry
+	}
 	return &ViewLayer{
-		entities: map[*EntityHandle]layer{},
-		blocks:   map[cube.Pos]Block{},
-		updater:  updater,
+		entities:      map[*EntityHandle]layer{},
+		blocks:        map[cube.Pos]uint32{},
+		blockRegistry: br,
+		updater:       updater,
 	}
 }
 
@@ -132,7 +143,7 @@ func (v *ViewLayer) ViewBlock(pos cube.Pos, b Block) {
 	if b == nil {
 		delete(v.blocks, pos)
 	} else {
-		v.blocks[pos] = b
+		v.blocks[pos] = v.blockRegistry.BlockRuntimeID(b)
 	}
 	v.mu.Unlock()
 
@@ -149,7 +160,11 @@ func (v *ViewLayer) Block(pos cube.Pos) (Block, bool) {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 
-	b, ok := v.blocks[pos]
+	rid, ok := v.blocks[pos]
+	if !ok {
+		return nil, false
+	}
+	b, ok := v.blockRegistry.BlockByRuntimeID(rid)
 	return b, ok
 }
 
@@ -158,7 +173,13 @@ func (v *ViewLayer) Blocks() map[cube.Pos]Block {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 
-	return maps.Clone(v.blocks)
+	blocks := make(map[cube.Pos]Block, len(v.blocks))
+	for pos, rid := range v.blocks {
+		if b, ok := v.blockRegistry.BlockByRuntimeID(rid); ok {
+			blocks[pos] = b
+		}
+	}
+	return blocks
 }
 
 // Remove removes all overrides for the entity from the ViewLayer.


### PR DESCRIPTION
Cursor review mirror of df-mc/dragonfly#1249

Original: https://github.com/df-mc/dragonfly/pull/1249

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core player block interaction, chunk encoding, and client sync paths; incorrect override handling could desync clients or leak private edits to the world.
> 
> **Overview**
> Adds **per-player block view layers** alongside the existing entity view-layer: a player can see fake blocks at positions without changing the real world, and revert with `ViewPublicBlock`.
> 
> **ViewLayer** now stores block overrides (`ViewBlock`, `Block`, `Blocks`) and notifies sessions when they change. **Chunk** / **SubChunk** / **Palette** gain `Clone()` so chunk data can be copied before applying overrides. **Session** merges overrides into chunks sent to the client (`applyViewLayerToChunk`), applies them on `ViewBlockUpdate`, and refreshes overrides via `ViewLayerBlockChanged` (including sub-chunk height adverts when needed).
> 
> **Player** interaction uses the **visible** block (`viewedBlock` / `breakingBlock`): use/place on private blocks is blocked; breaking private blocks clears the override, shows break effects only to that player (no world drops/XP), and crack/particles/sounds route through `ViewPrivateBlockAction` while skipping viewers who have their own override at that position.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 223aae41b79fa191605da19ff56e19794de10078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-player view-layer: clients can see customized block appearances or revert to the public view.
  * Sessions can publish private or public block views; private breaks show effects only to the viewer while public breaks are broadcast.
  * Block-breaking uses the visible block for crack timing, particles, drops and XP.

* **Refactor**
  * View-layer overrides are consistently applied when serving chunks and sending block updates so per-player views are honored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HashimTheArab/dragonfly/pull/29)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->