### PR TITLE
Optimize BlockIntercepts allocations

### DIFF
--- a/server/block/cube/trace/bbox.go
+++ b/server/block/cube/trace/bbox.go
@@ -1,9 +1,10 @@
 package trace
 
 import (
+	"math"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/go-gl/mathgl/mgl64"
-	"math"
 )
 
 // BBoxResult is the result of a basic ray trace collision with a bounding box.
@@ -34,112 +35,98 @@ func (r BBoxResult) Face() cube.Face {
 // a zero BBoxResult is returned and ok is false.
 func BBoxIntercept(bb cube.BBox, start, end mgl64.Vec3) (result BBoxResult, ok bool) {
 	min, max := bb.Min(), bb.Max()
-	v1 := vec3OnLineWithX(start, end, min[0])
-	v2 := vec3OnLineWithX(start, end, max[0])
-	v3 := vec3OnLineWithY(start, end, min[1])
-	v4 := vec3OnLineWithY(start, end, max[1])
-	v5 := vec3OnLineWithZ(start, end, min[2])
-	v6 := vec3OnLineWithZ(start, end, max[2])
-
-	if v1 != nil && !bb.Vec3WithinYZ(*v1) {
-		v1 = nil
-	}
-	if v2 != nil && !bb.Vec3WithinYZ(*v2) {
-		v2 = nil
-	}
-	if v3 != nil && !bb.Vec3WithinXZ(*v3) {
-		v3 = nil
-	}
-	if v4 != nil && !bb.Vec3WithinXZ(*v4) {
-		v4 = nil
-	}
-	if v5 != nil && !bb.Vec3WithinXY(*v5) {
-		v5 = nil
-	}
-	if v6 != nil && !bb.Vec3WithinXY(*v6) {
-		v6 = nil
-	}
 
 	var (
-		vec  *mgl64.Vec3
-		dist = math.MaxFloat64
+		faces = [6]cube.Face{
+			cube.FaceWest,
+			cube.FaceEast,
+			cube.FaceDown,
+			cube.FaceUp,
+			cube.FaceNorth,
+			cube.FaceSouth,
+		}
+		vecs    [6]mgl64.Vec3
+		results [6]bool
 	)
 
-	for _, v := range [...]*mgl64.Vec3{v1, v2, v3, v4, v5, v6} {
-		if v == nil {
+	vecs[0], results[0] = vec3OnLineWithX(start, end, min[0])
+	vecs[1], results[1] = vec3OnLineWithX(start, end, max[0])
+	vecs[2], results[2] = vec3OnLineWithY(start, end, min[1])
+	vecs[3], results[3] = vec3OnLineWithY(start, end, max[1])
+	vecs[4], results[4] = vec3OnLineWithZ(start, end, min[2])
+	vecs[5], results[5] = vec3OnLineWithZ(start, end, max[2])
+
+	results[0] = results[0] && bb.Vec3WithinYZ(vecs[0])
+	results[1] = results[1] && bb.Vec3WithinYZ(vecs[1])
+	results[2] = results[2] && bb.Vec3WithinXZ(vecs[2])
+	results[3] = results[3] && bb.Vec3WithinXZ(vecs[3])
+	results[4] = results[4] && bb.Vec3WithinXY(vecs[4])
+	results[5] = results[5] && bb.Vec3WithinXY(vecs[5])
+
+	var (
+		vec  mgl64.Vec3
+		dist = math.MaxFloat64
+		face cube.Face
+		has  bool
+	)
+
+	for i := range 6 {
+		if !results[i] {
 			continue
 		}
-
-		if d := start.Sub(*v).LenSqr(); d < dist {
+		v := vecs[i]
+		if d := start.Sub(v).LenSqr(); d < dist {
 			vec = v
 			dist = d
+			has = true
+			face = faces[i]
 		}
 	}
 
-	if vec == nil {
-		return
-	}
-
-	var f cube.Face
-	switch vec {
-	case v1:
-		f = cube.FaceWest
-	case v2:
-		f = cube.FaceEast
-	case v3:
-		f = cube.FaceDown
-	case v4:
-		f = cube.FaceUp
-	case v5:
-		f = cube.FaceNorth
-	case v6:
-		f = cube.FaceSouth
-	}
-
-	return BBoxResult{bb: bb, pos: *vec, face: f}, true
+	return BBoxResult{bb: bb, pos: vec, face: face}, has
 }
 
 // vec3OnLineWithX returns an mgl64.Vec3 on the line between mgl64.Vec3 a and b with an X value passed. If no such vec3
 // could be found, the bool returned is false.
-func vec3OnLineWithX(a, b mgl64.Vec3, x float64) *mgl64.Vec3 {
+func vec3OnLineWithX(a, b mgl64.Vec3, x float64) (mgl64.Vec3, bool) {
 	if mgl64.FloatEqual(b[0], a[0]) {
-		return nil
+		return mgl64.Vec3{}, false
 	}
 
 	f := (x - a[0]) / (b[0] - a[0])
 	if f < 0 || f > 1 {
-		return nil
+		return mgl64.Vec3{}, false
 	}
 
-	return &mgl64.Vec3{x, a[1] + (b[1]-a[1])*f, a[2] + (b[2]-a[2])*f}
+	return mgl64.Vec3{x, a[1] + (b[1]-a[1])*f, a[2] + (b[2]-a[2])*f}, true
 }
 
 // vec3OnLineWithY returns an mgl64.Vec3 on the line between mgl64.Vec3 a and b with a Y value passed. If no such vec3
 // could be found, the bool returned is false.
-func vec3OnLineWithY(a, b mgl64.Vec3, y float64) *mgl64.Vec3 {
+func vec3OnLineWithY(a, b mgl64.Vec3, y float64) (mgl64.Vec3, bool) {
 	if mgl64.FloatEqual(a[1], b[1]) {
-		return nil
+		return mgl64.Vec3{}, false
 	}
 
 	f := (y - a[1]) / (b[1] - a[1])
 	if f < 0 || f > 1 {
-		return nil
+		return mgl64.Vec3{}, false
 	}
 
-	return &mgl64.Vec3{a[0] + (b[0]-a[0])*f, y, a[2] + (b[2]-a[2])*f}
+	return mgl64.Vec3{a[0] + (b[0]-a[0])*f, y, a[2] + (b[2]-a[2])*f}, true
 }
 
 // vec3OnLineWithZ returns an mgl64.Vec3 on the line between mgl64.Vec3 a and b with a Z value passed. If no such vec3
 // could be found, the bool returned is false.
-func vec3OnLineWithZ(a, b mgl64.Vec3, z float64) *mgl64.Vec3 {
+func vec3OnLineWithZ(a, b mgl64.Vec3, z float64) (mgl64.Vec3, bool) {
 	if mgl64.FloatEqual(a[2], b[2]) {
-		return nil
+		return mgl64.Vec3{}, false
 	}
 
 	f := (z - a[2]) / (b[2] - a[2])
 	if f < 0 || f > 1 {
-		return nil
+		return mgl64.Vec3{}, false
 	}
 
-	return &mgl64.Vec3{a[0] + (b[0]-a[0])*f, a[1] + (b[1]-a[1])*f, z}
+	return mgl64.Vec3{a[0] + (b[0]-a[0])*f, a[1] + (b[1]-a[1])*f, z}, false
 }

--- a/server/block/cube/trace/bbox.go
+++ b/server/block/cube/trace/bbox.go
@@ -128,5 +128,5 @@ func vec3OnLineWithZ(a, b mgl64.Vec3, z float64) (mgl64.Vec3, bool) {
 		return mgl64.Vec3{}, false
 	}
 
-	return mgl64.Vec3{a[0] + (b[0]-a[0])*f, a[1] + (b[1]-a[1])*f, z}, false
+	return mgl64.Vec3{a[0] + (b[0]-a[0])*f, a[1] + (b[1]-a[1])*f, z}, true
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized performance refactor in ray–bbox math with the same public API; main risk is subtle numeric/face-selection regressions if edge cases differ from pointer-based equality.
> 
> **Overview**
> Refactors **`BBoxIntercept`** in `server/block/cube/trace/bbox.go` so ray–box intersection no longer allocates on the heap. The six slab intersection helpers now return **`(mgl64.Vec3, bool)`** instead of **`*mgl64.Vec3`**, and candidates are stored in fixed **`[6]`** slices for positions, validity flags, and **`cube.Face`** values.
> 
> The closest hit and hit face are chosen in a single loop by index, replacing the old pointer-equality **`switch`** on which slab won. **`BBoxIntercept`**’s signature and behavior for callers are unchanged; only internal allocation patterns and how the winning face is determined differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de4cce4a3692b3e0f56655f3a6ffc0317e89fc17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal ray-box intersection calculations through improved algorithm structure and helper function behavior.

**Note:** This is an internal code improvement with no visible end-user impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HashimTheArab/dragonfly/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->