### PR TITLE
[codex] Add typed command source runnables

### DIFF
--- a/server/cmd/command.go
+++ b/server/cmd/command.go
@@ -11,11 +11,12 @@ import (
 	"github.com/df-mc/dragonfly/server/world"
 )
 
-// Runnable represents a Command that may be run by a Command source. The Command must be a struct type and
-// its fields represent the parameters of the Command. When the Run method is called, these fields are set
-// and may be used for behaviour in the Command. Fields unexported or ignored using the `cmd:"-"` struct tag (see
-// below) have their values copied but retained.
-// A Runnable may have exported fields only of the following types:
+// Runnable represents a Command that may be run by any Command source. The Command must be a struct type and
+// its fields represent the parameters of the Command. Commands that only support a specific source type may
+// implement RunnableFor and be registered with NewFor instead. When the Run method is called, these fields
+// are set and may be used for behaviour in the Command. Fields unexported or ignored using the `cmd:"-"`
+// struct tag (see below) have their values copied but retained.
+// A Runnable or RunnableFor may have exported fields only of the following types:
 // int8, int16, int32, int64, int, uint8, uint16, uint32, uint64, uint,
 // float32, float64, string, bool, mgl64.Vec3, Varargs, []Target, cmd.SubCommand, Optional[T] (to make a parameter
 // optional), or a type that implements the cmd.Parameter or cmd.Enum interface. cmd.Enum implementations must be of the
@@ -35,6 +36,24 @@ type Runnable interface {
 	Run(src Source, o *Output, tx *world.Tx)
 }
 
+// Context holds the values available while running a typed command.
+type Context[S Source] struct {
+	// Source is the typed source that executed the command.
+	Source S
+	// Output holds messages that will be sent to Source after the command has run.
+	Output *Output
+	// Tx is the world transaction the command is currently running in.
+	Tx *world.Tx
+}
+
+// RunnableFor represents a Command that may only be run by command sources assignable to S.
+// RunnableFor implementations are registered using NewFor.
+type RunnableFor[S Source] interface {
+	// Run runs the Command, using the arguments passed to the Command. The Context passed contains the
+	// typed source of the Command execution and the output to which messages may be added.
+	Run(ctx *Context[S])
+}
+
 // Allower may be implemented by a type also implementing Runnable to limit the sources that may run the
 // command.
 type Allower interface {
@@ -43,10 +62,25 @@ type Allower interface {
 	Allow(src Source) bool
 }
 
+// AllowerFor may be implemented by a type also implementing RunnableFor to limit the typed sources that may
+// run the command.
+type AllowerFor[S Source] interface {
+	// Allow checks if the source passed is allowed to execute the command. True is returned if the source is
+	// allowed to execute the command.
+	Allow(src S) bool
+}
+
+type commandRunnable struct {
+	value    reflect.Value
+	run      func(v reflect.Value, src Source, o *Output, tx *world.Tx)
+	allow    func(v reflect.Value, src Source) bool
+	runnable func(v reflect.Value) Runnable
+}
+
 // Command is a wrapper around a Runnable. It provides additional identity and utility methods for the actual
 // runnable command so that it may be identified more easily.
 type Command struct {
-	v           []reflect.Value
+	v           []commandRunnable
 	name        string
 	description string
 	usage       string
@@ -60,36 +94,144 @@ type Command struct {
 // called after all fields have their values from the parsed command set. If r
 // is not a struct or a pointer to a struct, New panics.
 func New(name, description string, aliases []string, r ...Runnable) Command {
+	runnables := make([]commandRunnable, len(r))
+	for i, runnable := range r {
+		value := runnableValue(runnable)
+		runnables[i] = commandRunnable{
+			value: value,
+			run: func(v reflect.Value, src Source, o *Output, tx *world.Tx) {
+				v.Interface().(Runnable).Run(src, o, tx)
+			},
+			allow: func(v reflect.Value, src Source) bool {
+				a, ok := v.Interface().(Allower)
+				return !ok || a.Allow(src)
+			},
+			runnable: func(v reflect.Value) Runnable {
+				if r, ok := interfaceFromValue[Runnable](value); ok {
+					return r
+				}
+				return v.Interface().(Runnable)
+			},
+		}
+	}
+	return newCommand(name, description, aliases, runnables)
+}
+
+// NewFor returns a new Command that may only be run by sources assignable to S. Command names and aliases
+// are all converted to lowercase. The RunnableFor values passed must be a (pointer to a) struct, with their
+// fields representing the parameters of the command. When the command is run, the Run method of the
+// RunnableFor will be called with a Context holding the typed source and parsed output. If r is not a struct
+// or a pointer to a struct, NewFor panics.
+func NewFor[S Source](name, description string, aliases []string, r ...RunnableFor[S]) Command {
+	runnables := make([]commandRunnable, len(r))
+	for i, runnable := range r {
+		runnables[i] = commandRunnable{
+			value: runnableValue(runnable),
+			run: func(v reflect.Value, src Source, o *Output, tx *world.Tx) {
+				typedSrc, ok := src.(S)
+				if !ok {
+					return
+				}
+				v.Interface().(RunnableFor[S]).Run(&Context[S]{Source: typedSrc, Output: o, Tx: tx})
+			},
+			allow: func(v reflect.Value, src Source) bool {
+				typedSrc, ok := src.(S)
+				if !ok {
+					return false
+				}
+				if a, ok := v.Interface().(AllowerFor[S]); ok && !a.Allow(typedSrc) {
+					return false
+				}
+				if a, ok := v.Interface().(Allower); ok && !a.Allow(src) {
+					return false
+				}
+				return true
+			},
+			runnable: func(v reflect.Value) Runnable {
+				return typedRunnable[S]{v: v}
+			},
+		}
+	}
+	return newCommand(name, description, aliases, runnables)
+}
+
+func newCommand(name, description string, aliases []string, r []commandRunnable) Command {
 	name = strings.ToLower(name)
 	for i, alias := range aliases {
 		aliases[i] = strings.ToLower(alias)
 	}
 
 	usages := make([]string, len(r))
-	runnableValues := make([]reflect.Value, len(r))
 
 	if len(aliases) > 0 && slices.Index(aliases, name) == -1 {
 		aliases = append(aliases, name)
 	}
 
 	for i, runnable := range r {
-		t := reflect.TypeOf(runnable)
-		if t.Kind() != reflect.Struct && (t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct) {
-			panic(fmt.Sprintf("Runnable r must be struct or pointer to struct, but got %v", t.Kind()))
-		}
-		original := reflect.ValueOf(runnable)
-		if t.Kind() == reflect.Ptr {
-			original = original.Elem()
-		}
-
-		cp := reflect.New(original.Type()).Elem()
+		cp := reflect.New(runnable.value.Type()).Elem()
 		if err := verifySignature(cp); err != nil {
 			panic(err.Error())
 		}
-		runnableValues[i], usages[i] = original, parseUsage(name, cp)
+		usages[i] = parseUsage(name, cp)
 	}
 
-	return Command{name: name, description: description, aliases: aliases, v: runnableValues, usage: strings.Join(usages, "\n")}
+	return Command{name: name, description: description, aliases: aliases, v: r, usage: strings.Join(usages, "\n")}
+}
+
+func runnableValue(r any) reflect.Value {
+	if r == nil {
+		panic("Runnable r must be struct or pointer to struct, but got <nil>")
+	}
+	t := reflect.TypeOf(r)
+	if t.Kind() != reflect.Struct && (t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct) {
+		panic(fmt.Sprintf("Runnable r must be struct or pointer to struct, but got %v", t.Kind()))
+	}
+	original := reflect.ValueOf(r)
+	if t.Kind() == reflect.Ptr {
+		if original.IsNil() {
+			panic("Runnable r must be struct or pointer to struct, but got nil pointer")
+		}
+		original = original.Elem()
+	}
+	return original
+}
+
+func newRunnableValue(original reflect.Value) reflect.Value {
+	cp := reflect.New(original.Type())
+	cp.Elem().Set(original)
+	return cp
+}
+
+func interfaceFromValue[T any](v reflect.Value) (T, bool) {
+	if v.CanInterface() {
+		if t, ok := v.Interface().(T); ok {
+			return t, true
+		}
+	}
+	if v.CanAddr() {
+		if t, ok := v.Addr().Interface().(T); ok {
+			return t, true
+		}
+	}
+	cp := newRunnableValue(v)
+	if t, ok := cp.Interface().(T); ok {
+		return t, true
+	}
+	var zero T
+	return zero, false
+}
+
+type typedRunnable[S Source] struct {
+	v reflect.Value
+}
+
+// Run adapts a RunnableFor to Runnable for APIs that still expose runnable values.
+func (r typedRunnable[S]) Run(src Source, o *Output, tx *world.Tx) {
+	typedSrc, ok := src.(S)
+	if !ok {
+		return
+	}
+	r.v.Interface().(RunnableFor[S]).Run(&Context[S]{Source: typedSrc, Output: o, Tx: tx})
 }
 
 // Name returns the name of the command. The name is guaranteed to be lowercase and will never have spaces in
@@ -133,10 +275,8 @@ func (cmd Command) Execute(args string, source Source, tx *world.Tx) {
 	var leastErroneous error
 	var leastArgsLeft *Line
 
-	for _, v := range cmd.v {
-		cp := reflect.New(v.Type())
-		cp.Elem().Set(v)
-		line, err := cmd.executeRunnable(cp, args, source, output, tx)
+	for _, runnable := range cmd.v {
+		line, err := cmd.executeRunnable(runnable, args, source, output, tx)
 		if err == nil {
 			// Command was executed successfully: We won't execute any of the other Runnable values passed, as
 			// we've already found an overload that works.
@@ -179,19 +319,19 @@ type ParamInfo struct {
 func (cmd Command) Params(src Source) [][]ParamInfo {
 	params := make([][]ParamInfo, 0, len(cmd.v))
 	for _, runnable := range cmd.v {
-		if allower, ok := runnable.Interface().(Allower); ok && !allower.Allow(src) {
+		if !runnable.allow(newRunnableValue(runnable.value), src) {
 			// This source cannot execute this runnable.
 			continue
 		}
 
 		// If the runnable can describe its own parameters, prefer that over reflection.
-		if d, ok := runnable.Interface().(ParamDescriber); ok {
+		if d, ok := interfaceFromValue[ParamDescriber](runnable.value); ok {
 			params = append(params, d.DescribeParams(src))
 			continue
 		}
 
-		elem := reflect.New(runnable.Type()).Elem()
-		elem.Set(runnable)
+		elem := reflect.New(runnable.value.Type()).Elem()
+		elem.Set(runnable.value)
 
 		var fields []ParamInfo
 		for _, t := range exportedFields(elem) {
@@ -212,9 +352,9 @@ func (cmd Command) Params(src Source) [][]ParamInfo {
 func (cmd Command) Runnables(src Source) map[int]Runnable {
 	m := make(map[int]Runnable, len(cmd.v))
 	for i, runnable := range cmd.v {
-		v := runnable.Interface().(Runnable)
-		if allower, ok := v.(Allower); !ok || allower.Allow(src) {
-			m[i] = v
+		v := newRunnableValue(runnable.value)
+		if runnable.allow(v, src) {
+			m[i] = runnable.runnable(v)
 		}
 	}
 	return m
@@ -229,8 +369,9 @@ func (cmd Command) String() string {
 // executeRunnable executes a Runnable v, by parsing the args passed using the source and output obtained. If
 // parsing was not successful or the Runnable could not be run by this source, an error is returned, and the
 // leftover command line.
-func (cmd Command) executeRunnable(v reflect.Value, args string, source Source, output *Output, tx *world.Tx) (*Line, error) {
-	if a, ok := v.Interface().(Allower); ok && !a.Allow(source) {
+func (cmd Command) executeRunnable(runnable commandRunnable, args string, source Source, output *Output, tx *world.Tx) (*Line, error) {
+	v := newRunnableValue(runnable.value)
+	if !runnable.allow(v, source) {
 		return nil, MessageUnknown.F(cmd.name)
 	}
 
@@ -277,7 +418,7 @@ func (cmd Command) executeRunnable(v reflect.Value, args string, source Source, 
 		return arguments, arguments.UsageError()
 	}
 
-	v.Interface().(Runnable).Run(source, output, tx)
+	runnable.run(v, source, output, tx)
 	return arguments, nil
 }
 

--- a/server/cmd/command_test.go
+++ b/server/cmd/command_test.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/go-gl/mathgl/mgl64"
+)
+
+type testSource struct {
+	output *Output
+}
+
+func (s *testSource) Position() mgl64.Vec3 { return mgl64.Vec3{} }
+
+func (s *testSource) SendCommandOutput(o *Output) {
+	s.output = o
+}
+
+type typedTestSource struct {
+	testSource
+	allowed bool
+}
+
+type otherTestSource struct {
+	testSource
+}
+
+type typedEchoCommand struct {
+	Message string
+}
+
+var typedEchoRun struct {
+	source  *typedTestSource
+	output  *Output
+	tx      *world.Tx
+	message string
+}
+
+func (c typedEchoCommand) Run(ctx *Context[*typedTestSource]) {
+	typedEchoRun.source = ctx.Source
+	typedEchoRun.output = ctx.Output
+	typedEchoRun.tx = ctx.Tx
+	typedEchoRun.message = c.Message
+	ctx.Output.Print(c.Message)
+}
+
+func TestNewForRunsWithTypedSource(t *testing.T) {
+	typedEchoRun = struct {
+		source  *typedTestSource
+		output  *Output
+		tx      *world.Tx
+		message string
+	}{}
+
+	command := NewFor[*typedTestSource]("echo", "echoes a message", nil, typedEchoCommand{})
+	source := &typedTestSource{}
+
+	command.Execute("hello", source, nil)
+
+	if typedEchoRun.source != source {
+		t.Fatalf("typed command source = %v, want %v", typedEchoRun.source, source)
+	}
+	if typedEchoRun.output == nil {
+		t.Fatal("typed command output was nil")
+	}
+	if typedEchoRun.tx != nil {
+		t.Fatalf("typed command tx = %v, want nil", typedEchoRun.tx)
+	}
+	if typedEchoRun.message != "hello" {
+		t.Fatalf("typed command message = %q, want hello", typedEchoRun.message)
+	}
+	if source.output == nil || source.output.MessageCount() != 1 || source.output.Messages()[0].String() != "hello" {
+		t.Fatalf("source output = %#v, want one hello message", source.output)
+	}
+}
+
+func TestNewForFiltersOtherSources(t *testing.T) {
+	typedEchoRun = struct {
+		source  *typedTestSource
+		output  *Output
+		tx      *world.Tx
+		message string
+	}{}
+
+	command := NewFor[*typedTestSource]("echo", "echoes a message", nil, typedEchoCommand{})
+	source := &otherTestSource{}
+
+	if params := command.Params(source); len(params) != 0 {
+		t.Fatalf("Params returned %d overloads for wrong source type, want 0", len(params))
+	}
+	if runnables := command.Runnables(source); len(runnables) != 0 {
+		t.Fatalf("Runnables returned %d overloads for wrong source type, want 0", len(runnables))
+	}
+
+	command.Execute("hello", source, nil)
+
+	if typedEchoRun.source != nil {
+		t.Fatalf("typed command ran with wrong source type: %v", typedEchoRun.source)
+	}
+	if source.output == nil || source.output.ErrorCount() == 0 {
+		t.Fatalf("source output = %#v, want command error", source.output)
+	}
+}
+
+type typedAllowedCommand struct{}
+
+var typedAllowedRan bool
+
+func (typedAllowedCommand) Allow(src *typedTestSource) bool {
+	return src.allowed
+}
+
+func (typedAllowedCommand) Run(ctx *Context[*typedTestSource]) {
+	typedAllowedRan = true
+	ctx.Output.Print("allowed")
+}
+
+func TestNewForHonoursTypedAllower(t *testing.T) {
+	typedAllowedRan = false
+	command := NewFor[*typedTestSource]("allowed", "checks typed source permissions", nil, typedAllowedCommand{})
+	disallowed := &typedTestSource{}
+
+	if params := command.Params(disallowed); len(params) != 0 {
+		t.Fatalf("Params returned %d overloads for disallowed source, want 0", len(params))
+	}
+	if runnables := command.Runnables(disallowed); len(runnables) != 0 {
+		t.Fatalf("Runnables returned %d overloads for disallowed source, want 0", len(runnables))
+	}
+	command.Execute("", disallowed, nil)
+	if typedAllowedRan {
+		t.Fatal("typed command ran for disallowed source")
+	}
+
+	allowed := &typedTestSource{allowed: true}
+	command.Execute("", allowed, nil)
+	if !typedAllowedRan {
+		t.Fatal("typed command did not run for allowed source")
+	}
+	if allowed.output == nil || allowed.output.MessageCount() != 1 || allowed.output.Messages()[0].String() != "allowed" {
+		t.Fatalf("allowed output = %#v, want one allowed message", allowed.output)
+	}
+}
+
+type typedPointerCommand struct {
+	Message string
+}
+
+var typedPointerMessage string
+
+func (c *typedPointerCommand) Run(ctx *Context[*typedTestSource]) {
+	typedPointerMessage = c.Message
+	ctx.Output.Print(c.Message)
+}
+
+func TestNewForSupportsPointerReceiver(t *testing.T) {
+	typedPointerMessage = ""
+	command := NewFor[*typedTestSource]("pointer", "uses a pointer receiver", nil, &typedPointerCommand{})
+	source := &typedTestSource{}
+
+	command.Execute("hello", source, nil)
+
+	if typedPointerMessage != "hello" {
+		t.Fatalf("typed pointer command message = %q, want hello", typedPointerMessage)
+	}
+	if source.output == nil || source.output.MessageCount() != 1 || source.output.Messages()[0].String() != "hello" {
+		t.Fatalf("source output = %#v, want one hello message", source.output)
+	}
+}
+
+type legacyPointerCommand struct {
+	Message string
+}
+
+var legacyPointerMessage string
+
+func (c *legacyPointerCommand) Run(_ Source, o *Output, _ *world.Tx) {
+	legacyPointerMessage = c.Message
+	o.Print(c.Message)
+}
+
+func TestNewStillSupportsLegacyPointerReceiver(t *testing.T) {
+	legacyPointerMessage = ""
+	command := New("legacy", "uses the legacy Runnable signature", nil, &legacyPointerCommand{})
+	source := &typedTestSource{}
+
+	command.Execute("hello", source, nil)
+
+	if legacyPointerMessage != "hello" {
+		t.Fatalf("legacy pointer command message = %q, want hello", legacyPointerMessage)
+	}
+	if source.output == nil || source.output.MessageCount() != 1 || source.output.Messages()[0].String() != "hello" {
+		t.Fatalf("source output = %#v, want one hello message", source.output)
+	}
+}

--- a/server/cmd/doc.go
+++ b/server/cmd/doc.go
@@ -2,12 +2,13 @@
 // and sending commands registered in an AvailableCommandsPacket.
 //
 // The cmd package handles commands in a specific way: It requires a struct to be passed to the cmd.New()
-// function, which implements the Runnable interface. For every exported field in the struct, executing the
-// command will result in the parsing of the arguments using the types of the fields of the struct, in the
-// order that they appear in. Fields unexported or ignored using the `cmd:"-"` struct tag (see below) have
-// their values copied but retained.
+// function, which implements the Runnable interface, or to cmd.NewFor(), which implements the typed
+// RunnableFor[S] interface. For every exported field in the struct, executing the command will result in the
+// parsing of the arguments using the types of the fields of the struct, in the order that they appear in.
+// Fields unexported or ignored using the `cmd:"-"` struct tag (see below) have their values copied but
+// retained.
 //
-// A Runnable may have exported fields only of the following types:
+// A Runnable or RunnableFor may have exported fields only of the following types:
 // int8, int16, int32, int64, int, uint8, uint16, uint32, uint64, uint,
 // float32, float64, string, bool, mgl64.Vec3, Varargs, []Target, cmd.SubCommand, Optional[T] (to make a parameter
 // optional), or a type that implements the cmd.Parameter or cmd.Enum interface. cmd.Enum implementations must be of the
@@ -20,6 +21,19 @@
 //
 // If no name is set, the field name is used. Additionally, the name as specified in the struct tag may be '-' to make
 // the parser ignore the field. In this case, the field does not have to be of one of the types above.
+//
+// Commands that only support a specific source type may use cmd.NewFor() instead of manually asserting the
+// source type in Run:
+//
+//	type Hello struct{}
+//
+//	func (Hello) Run(ctx *cmd.Context[*player.Player]) {
+//	    ctx.Source.Message("hello")
+//	}
+//
+//	cmd.Register(cmd.NewFor[*player.Player]("hello", "Says hello.", nil, Hello{}))
+//
+// The command will only be visible to and executable by sources assignable to *player.Player.
 //
 // Commands may be registered using the cmd.Register() method. By itself, this method will not ensure that the
 // client will be able to use the command: The user of the cmd package must handle commands itself and run the


### PR DESCRIPTION
## Summary

- Add `cmd.NewFor[S]`, `cmd.RunnableFor[S]`, `cmd.AllowerFor[S]`, and `cmd.Context[S]` for source-typed commands.
- Keep the existing `cmd.New` / `cmd.Runnable` API compatible while routing both legacy and typed commands through the same parsing/visibility path.
- Document the player-command UX so commands can avoid manual `cmd.Source` assertions.
- Add focused command tests covering typed source execution, wrong-source filtering, typed allowers, pointer receivers, and legacy compatibility.

This is intentionally separate from the world-owner scheduler refactor; `cmd.Context[S].Tx` remains a compatibility bridge for the current command execution model.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --cached --check`
- `codex-review` helper with `--parallel-tests "go test ./..."` returned clean: no accepted/actionable findings.

## Notes

- `cmd` does not import `player`; callers instantiate the generic API as `cmd.NewFor[*player.Player](...)` or with any other `cmd.Source` implementation.